### PR TITLE
Profile is not exclusive, removing additional profiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,27 +135,10 @@
             the <a>WoT Core Profile</a> can interoperate with each other
             out-of-the-box.
         </p>
-        <p>A later version of this document will define additional
-            profiles:</p>
-        <ul>
-            <li><strong>Thing Template Profile</strong>
-                <p>
-                    The <a>Thing Template Profile</a> enables to apply
-                    the vocabulary of the <a>Thing Description</a>
-                    Specification for defining a common interface, that
-                    can be implemented by different things. It selects
-                    an appropriate subset to describe <strong>classes</strong>
-                    of things that share the same data model.
-                </p></li>
-
-            <li><strong>Digital Twin Profile</strong>
-                <p>
-                    The <a>Digital Twin Profile</a> allows defining a
-                    virtual model of a thing or a group of things.
-                </p></li>
-        </ul>
-        <p>Profiles are is not exclusive, they can overlap or
-            include others.
+        <p>Note that the core profile is not exclusive. Device implementers are free to adopt 
+	    other features of the thing description that go beyond the constraints 
+	    of the core profile, however the interoperability guarantees of the core profile
+	    hold only for the <a>WoT Core Profile</a> subset.
     </section>
 
     <section id='sotd'></section>


### PR DESCRIPTION
Removing text for Digital Twin and Thing Templates for Spec version 1.0.
Adding text to clarify that the profile is not exclusive.

This MR addresses and resolves:
https://github.com/w3c/wot-profile/issues/9
https://github.com/w3c/wot-profile/issues/18
https://github.com/w3c/wot-profile/issues/8


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/pull/20.html" title="Last updated on Jul 30, 2020, 7:19 AM UTC (885ecf6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/20/a89e32c...885ecf6.html" title="Last updated on Jul 30, 2020, 7:19 AM UTC (885ecf6)">Diff</a>