### PR TITLE
Editorial fixes for FPWD

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,15 +331,6 @@
             We use the terms <em>device</em> and <em>thing</em> in an
             interchangeable manner.
         </p>
-        <p>
-            The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;,
-            &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL
-            NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;,
-            &quot;RECOMMENDED&quot;, &quot;MAY&quot;, and
-            &quot;OPTIONAL&quot; in this document are to be interpreted
-            as described in RFC 2119. (<a
-                href="https://www.ietf.org/rfc/rfc2119.txt">https://www.ietf.org/rfc/rfc2119.txt</a>)
-        </p>
         <h4 id="additional-definitions-">Additional Definitions:</h4>
         <dl>
             <dt>

--- a/index.html
+++ b/index.html
@@ -11,13 +11,12 @@
             lint: {
                 "no-headingless-sections": false,
             },
-            specStatus: "ED",
+            specStatus: "FPWD",
             maxTocLevel: 6,
             processVersion: 2019,
             shortName: "wot-profile",
             copyrightStart: 2020,
-            wg: "Web of Things Working Group",
-            wgURI: "https://www.w3.org/WoT/WG/",
+            group: "wg/wot",
             wgPublicList: "public-wot-wg",
             edDraftURI: "https://w3c.github.io/wot-profile/",
             githubAPI: "https://api.github.com/repos/w3c/wot-profile",
@@ -97,26 +96,16 @@
 
 <body>
     <section id="abstract">
-        <p>The W3C WoT Thing Architecture [[wot-architecture]] and
-            WoT Thing Description [[wot-thing-description]] define a
-            powerful description mechanism and a format to describe
-            myriads of very different devices, which may be connected
-            over various protocols. The format is very flexible and open
-            and puts very few normative requirements on devices that
-            implement it.</p>
-
-        <p>
-            However, this flexibility de-facto prevents
-            interoperability, since, without additional <strong>rules</strong>,
-            it allows implementers to make many choices that do not
-            provide <strong>guarantees</strong> of common behavior
-            between implementations.
+      <p>
+      The present document defines a WoT Profile that enables out of the box interoperability
+      among it's adopterts. It defines a set of constraints and rules that compliant 
+      thing descriptions have to adopt to ensure interoperability.
         </p>
         <p>
-            These rules have to be prescriptive, to ensure that
+            These rules are prescriptive, to ensure that
             compliant implementations satisfy the semantic guarantees,
             that are implied by them. We call this set of rules a <a>Profile</a>.
-
+       </p>
         <p>
             The <strong>WoT Profile Specification</strong> as defined in
             the present document serves two purposes:
@@ -146,6 +135,29 @@
             other features of the thing description that go beyond the constraints
             of the core profile, however the interoperability guarantees of the core profile
             hold only for the <a>WoT Core Profile</a> subset.
+
+          <section>
+            <h3>Motivatino for a Profile</h3>
+          </section>
+
+            <p>The W3C WoT Thing Architecture [[wot-architecture]] and
+              WoT Thing Description [[wot-thing-description]] define a
+              powerful description mechanism and a format to describe
+              myriads of very different devices, which may be connected
+              over various protocols. The format is very flexible and open
+              and puts very few normative requirements on devices that
+              implement it.</p>
+  
+          <p>
+              However, this flexibility de-facto prevents
+              interoperability, since, without additional <strong>rules</strong>,
+              it allows implementers to make many choices that do not
+              provide <strong>guarantees</strong> of common behavior
+              between implementations.
+          </p>
+  
+
+
     </section>
 
     <section id='sotd'></section>
@@ -350,20 +362,19 @@
             <dt>
                 <dfn>Thing Description Specification</dfn>
             </dt>
-            <dd>The WoT Thing Description Specification
-                [[wot-thing-description]].</dd>
+            <dd>The WoT Thing Description Specification.</dd>
             <dt>
                 <dfn>Thing Description</dfn>
             </dt>
             <dd>A Data Model that conforms to the Thing Description
-                specification [[wot-thing-description]].</dd>
+                Specification.</dd>
             <dt>
             <dt>
                 <dfn>Core Data Model</dfn>
             </dt>
             <dd>
                 A Data Model that conforms to the subset of the Thing
-                Description specification [[wot-thing-description]] as
+                Description specification as
                 defined in section <a href="wot-core-datamodel"></a>.
             </dd>
             <dt>

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
     <section id="abstract">
       <p>
       The present document defines a WoT Profile that enables out of the box interoperability
-      among it's adopterts. It defines a set of constraints and rules that compliant 
+      among things and devices. It defines a set of constraints and rules that compliant 
       thing descriptions have to adopt to ensure interoperability.
         </p>
         <p>
@@ -137,7 +137,7 @@
             hold only for the <a>WoT Core Profile</a> subset.
 
           <section>
-            <h3>Motivatino for a Profile</h3>
+            <h3>Motivation for a Profile</h3>
           </section>
 
             <p>The W3C WoT Thing Architecture [[wot-architecture]] and


### PR DESCRIPTION
This MR changes the document status to FPWD and rearranges the paragraphs in the "abstract" section. 

These changes are editorial only, no further modifications were done.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mlagally/wot-profile-1/pull/36.html" title="Last updated on Oct 1, 2020, 12:45 PM UTC (278d1b7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/36/fddca4a...mlagally:278d1b7.html" title="Last updated on Oct 1, 2020, 12:45 PM UTC (278d1b7)">Diff</a>