### PR TITLE
make the title "Web of Things (WoT) Profile"

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8" />
   <link rel="stylesheet" href="tablestyle.css">
-  <title>Web of Things (WoT): WoT Profile</title>
+  <title>Web of Things (WoT) Profile</title>
   <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
   <script class="remove">
     var respecConfig = {


### PR DESCRIPTION
All the other WoT specs have the name of "Web of Things (WoT) ...", so I think it would be better to make the title of the WoT Profile spec as well consistent with the notation :)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/pull/53.html" title="Last updated on Nov 4, 2020, 3:02 PM UTC (c87cad5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/53/83236c1...c87cad5.html" title="Last updated on Nov 4, 2020, 3:02 PM UTC (c87cad5)">Diff</a>