### PR TITLE
RFC 2119 markup: add css mark <span> into index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-US"
 
 <head>
   <meta charset="utf-8" />
@@ -93,6 +93,12 @@
       }
     };
   </script>
+  <style>
+    .rfc2119-assertion {
+      background-color: rgb(230,230,230)
+    }
+    </style>
+    
 </head>
 
 <body>
@@ -141,8 +147,10 @@
           will be defined in the near future.
         </p>
         <p>
+          <span class="rfc2119-assertion" id="profile-abstract-1">
           A TD that is compliant to the <a>core profile</a> MUST adhere to
           both the constraints on the data model and the protocol binding.
+          </span>
         </p>
       </li>
     </ul>
@@ -165,11 +173,15 @@
       <h3>Motivation for a Profile</h3>
     </section>
 
-    <p>The W3C WoT Thing Architecture [[wot-architecture]] and
+    <p>
+      <span class="rfc2119-assertion" id="profile-abstract-2">
+      The W3C WoT Thing Architecture [[wot-architecture]] and
       WoT Thing Description [[wot-thing-description]] define a
       powerful description mechanism and a format to describe
       myriads of very different devices, which may be connected
-      over various protocols. The format is very flexible and open
+      over various protocols. 
+      </span>
+      The format is very flexible and open
       and puts very few normative requirements on devices that
       implement it.</p>
 
@@ -272,9 +284,11 @@
         the implementers of PlugFest devices.
       </p>
       <p>
+        <span class="rfc2119-assertion" id="profile-1.2-why-a-core-profile-1">
         The <a>WoT Core Profile</a> contains additional
         normative requirements that MUST be satisfied by devices
         to be compliant to the profile.
+        </span>
       </p>
       <figure id="WoT-Core-Profile-figure">
         <img src="images/WoT Core Profile.png" class="wot-profiles" alt="WoT-Core-Profile-Picture" />
@@ -564,12 +578,20 @@
 
       <p>These two categories are orthogonal to each other,
         i.e. a data model that conforms to a profile can be
-        mapped to different protocols. The protocol binding for
+        mapped to different protocols. 
+        <span class="rfc2119-assertion" id="profile-4.1-profiling-mechanism-methodology-1">
+        The protocol binding for
         each protocol may contain additional (protocol-specific)
-        constraints.</p>
+        constraints.
+        </span>
+      </p>
 
-      <p>A profile is not exclusive, i.e. a thing may conform
-        to multiple profiles. Profiles can build on top of each
+      <p>
+        <span class="rfc2119-assertion" id="profile-4.1-profiling-mechanism-methodology-2"> 
+        A profile is not exclusive, i.e. a thing may conform
+        to multiple profiles. 
+        </span>
+        Profiles can build on top of each
         other or overlap, extended profiles can be built on top
         of the core profile.</p>
       <p>
@@ -612,8 +634,10 @@
         The normative rules defined by that data model
         are the baseline for the definition of the core data model
         and are normative for the core data model.
+        <span class="rfc2119-assertion" id="profile-5.1-wot-core-data-model-1">
         A core profile compliant implementation MUST additionally satisfy the
         requirements of this chapter.
+        </span>
       </p>
 
       <section id="general">
@@ -672,6 +696,7 @@
         </section>
 
         <p>
+          <span class="rfc2119-assertion" id="profile-5.1.1.2-wot-core-data-model-length-and-value-Limits-1">
           Where a type permits using an
           <code>array of string</code>
           or a
@@ -679,20 +704,24 @@
           , an
           <code>array of string</code>
           MUST be used.
+          </span>
 
         <section class="ednote">
           <p>TODO: decide if multiple types and contexts are required.</p>
 
           <p>In this case the following section could be added:</p>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.1.1.2-wot-core-data-model-length-and-value-Limits-2">
             The only exception to this rule are <code>@context</code> and <code>@type</code> annotations,
             where both <code>string</code> or <code>array of string</code> MAY be used.
+            </span>
           </p>
         </section>
 
         </p>
 
         <p>
+          <span class="rfc2119-assertion" id="profile-5.1.1.2-wot-core-data-model-length-and-value-Limits-3">
           Where a type permits using an
           <code>array of DataSchema</code>
           or a
@@ -700,17 +729,23 @@
           , an
           <code>array of DataSchema</code>
           MUST be used.
+          </span>
         </p>
         <p>
+          <span class="rfc2119-assertion" id="profile-5.1.1.2-wot-core-data-model-length-and-value-Limits-4">
           All elements of an
           <code>enum</code>
           MUST be either
           <code>string</code>
           or
           <code>number</code>
-          . Different types in a single
+          . 
+          </span>
+          <span class="rfc2119-assertion" id="profile-5.1.1.2-wot-core-data-model-length-and-value-Limits-5">
+          Different types in a single
           <code>enum</code>
           are NOT PERMITTED.
+          </span>
         </p>
         <!--  table class="def">
 				<thead>
@@ -745,9 +780,11 @@
         <section>
           <h3>Mandatory fields</h3>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.1.2.1-thing-mandatory-fields-1">
             To provide minimum interoperability, the
             following metadata fields of a <a>Thing</a> MUST
             be contained in a compliant Thing Description:
+            </span>
           </p>
           <table class="def">
             <thead>
@@ -811,19 +848,31 @@
             &quot;&quot; for strings, where the
             value cannot be determined.</p>
 
-          <p>If a Thing Description is used solely within
+          <p>
+            <span class="rfc2119-assertion" id="profile-5.1.2.1-thing-mandatory-fields-2">
+            If a Thing Description is used solely within
             a company, the email address of the developer
-            SHOULD be used in the support field, if the
-            Thing Description is provided externally, a support email
-            address SHOULD be used.</p>
+            SHOULD be used in the support field, 
+            </span>
+            <span class="rfc2119-assertion" id="profile-5.1.2.1-thing-mandatory-fields-3">
+            if the Thing Description is provided externally, a support email
+            address SHOULD be used.
+            </span>
+          </p>
 
           <section class="note">
             <p>
+              <span class="rfc2119-assertion" id="profile-5.1.2.1-thing-mandatory-fields-4"> 
               It will be evaluated whether the profile also recommends some new TD terms that may be
-              introduced in TD 1.1. Currently the following terms are discussed: serialNumber,
+              introduced in TD 1.1. 
+              </span>
+              Currently the following terms are discussed: serialNumber,
               hardwareRevision, softwareRevision, loc_latitude, loc_longitude
-              loc_altitude, loc_height, and loc_depth. If these, or some of them, are defined in the TD
+              loc_altitude, loc_height, and loc_depth. 
+              <span class="rfc2119-assertion" id="profile-5.1.2.1-mandatory-fields-5">
+              If these, or some of them, are defined in the TD
               1.1 model, they may be recommended here in one of the next draft updates.
+              </span>
             </p>
           </section>
         </section>
@@ -858,17 +907,23 @@
           The <a>Core Data Model</a> restricts the use of
           arrays and objects to the <strong>top level</strong>
           of Data Schemas, i.e. only a one-level hierarchy is
-          permitted. The members of a top level
+          permitted. 
+          <span class="rfc2119-assertion" id="profile-5.1.3-thing-data-schema-1">
+          The members of a top level
           <code>object</code>
           or
           <code>array</code>
           MUST NOT be array or object types.
+          </span>
         </p>
         <section class="note" title="RATIONALE">
-          <p>This may appear as a severe limitation,
+          <p>
+            <span class="rfc2119-assertion" id="profile-5.1.3-thing-data-schema-2"> 
+            This may appear as a severe limitation,
             however it is motivated by integrating with
-            multiple cloud services. Many enterprise
-            services and applications are based on
+            multiple cloud services. 
+            </span>
+            Many enterprise services and applications are based on
             (relational) databases, where individual
             property values are stored. Of course databases
             can also store objects (e.g. encoded as a JSON
@@ -886,8 +941,12 @@
             limited devices.
           </p>
         </section>
-        <p>The following fields MUST be contained in a
-          DataSchema:</p>
+        <p>
+          <span class="rfc2119-assertion" id="profile-5.1.3-thing-data-schema-3">
+          The following fields MUST be contained in a
+          DataSchema:
+          </span>
+        </p>
         <table class="def">
           <thead>
             <tr>
@@ -910,11 +969,15 @@
           </tbody>
         </table>
         <p>
+          <span class="rfc2119-assertion" id="profile-5.1.3-thing-data-schema-4">
           The values
           <code> object </code>
           ,
           <code> array </code> MAY only be used at the top level of a Data Schema.
+          </span>
+          <span class="rfc2119-assertion" id="profile-5.1.3-thing-data-schema-5">
           The type value MUST NOT be <code> null </code>.
+          </span>
         </p>
       </section>
 
@@ -930,10 +993,12 @@
         <section>
           <h4>Mandatory fields</h4>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.1.4.1-thing-property-affordance-mandatory-fields-1">
             The following property fields MUST be contained
             in the
             <code>properties</code>
             element of a <em>Profile compliant TD</em>:
+            </span>
           </p>
           <table class="def">
             <thead>
@@ -958,12 +1023,15 @@
               <tr>
                 <td>type</td>
                 <td>string</td>
-                <td>one of <code> boolean </code> ,
+                <td>
+                  <span class="rfc2119-assertion" id="profile-5.1.4.1-thing-property-affordance-mandatory-fields-2">
+                  one of <code> boolean </code> ,
                   <code> string </code> , <code>
                                         number </code> , <code> integer
                                     </code> , <code> object </code> or <code>
                                         array </code> . The type value <code>
                                         null </code> MUST NOT be used.
+                  </span>
                 </td>
               </tr>
             </tbody>
@@ -976,21 +1044,26 @@
             The <em>Thing Description</em> permits arbitrary
             object depths for properties. Parsing of a
             deeply nested structure is not possible on
-            resource constrained devices. Therefore each
-            property MUST NOT exceed a maximum depth
-	    of 5 levels of nested
+            resource constrained devices. 
+            <span class="rfc2119-assertion" id="profile-5.1.4.2-thing-property-affordance-additional-constraints-1">
+            Therefore each
+            property MUST NOT exceed a maximum depth 
+	          of 5 levels of nested
             <code>array</code>
             or
             <code>object</code>
-            elements. It is RECOMMENDED to keep the nesting
-	    of these elements below 4.
+            elements. It is RECOMMENDED to keep the nesting 
+	          of these elements below 4.
+            </span>
           </p>
 
           <p>
+            <span class="rfc2119-assertion" id="profile-5.1.4.2-thing-property-affordance-dditional-constraints-2">
             The following additional constraints MUST be
             applied to the Property Affordances of a <em>Thing
               Description</em> conforming to the <a>Core
               Profile</a>:
+            </span>
           </p>
           <table class="def">
             <thead>
@@ -1004,49 +1077,70 @@
               <tr>
                 <td>const</td>
                 <td>anyType</td>
-                <td>MUST NOT be used</td>
+                <td>
+                  <span class="rfc2119-assertion" id="profile-5.1.4.2-thing-property-affordance-additional-constraints-3">
+                  MUST NOT be used
+                  </span>
+                </td>
               </tr>
               <tr>
                 <td>enum</td>
                 <td>array of simple type</td>
-                <td><em>Values</em> of enums MAY
+                <td>
+                  <span class="rfc2119-assertion" id="profile-5.1.4.2-thing-property-affordance-additional-constraints-4">
+                  <em>Values</em> of enums MAY
                   only be simple types. Handling of <em>any
                     type</em> is too complex to implement
-                  on resource constrained devices</td>
+                  on resource constrained devices
+                  </span>
+                </td>
               </tr>
               <tr>
                 <td>forms</td>
                 <td>array of Forms</td>
-                <td>The <code>Array of Form</code>
+                <td>
+                  <span class="rfc2119-assertion" id="profile-5.1.4.2-thing-property-affordance-additional-constraints-5">
+                  The <code>Array of Form</code>
                   of each property MUST contain only a
                   <em>single endpoint</em> for each
                   operation <code>readproperty</code>
                   , <code>writeproperty</code> , <code>observeproperty</code>
                   , <code>unobserveproperty</code>.
+                  </span>
                 </td>
               </tr>
               <tr>
                 <td>format</td>
                 <td>string</td>
-                <td>If the field <code>format</code>
+                <td>
+                  <span class="rfc2119-assertion" id="profile-5.1.4.2-thing-property-affordance-additional-constraints-6">
+                  If the field <code>format</code>
                   is used, only formats defined in
                   section 7.3.1-7.3.6 of
                   [[JSON-SCHEMA]] MAY be used.
+                  </span>
                 </td>
               </tr>
               <tr>
                 <td>oneOf</td>
                 <td>string</td>
-                <td>The DataSchema field <code>oneOf</code>
+                <td>
+                  <span class="rfc2119-assertion" id="profile-5.1.4.2-thing-property-affordance-additional-constraints-7">
+                  The DataSchema field <code>oneOf</code>
                   does not make sense for properties
                   and MUST NOT be used.
+                  </span>
                 </td>
               </tr>
               <tr>
                 <td>uriVariables</td>
                 <td>Map of DataSchema</td>
-                <td><code>uriVariables</code> MUST
-                  NOT be used.</td>
+                <td>
+                  <span class="rfc2119-assertion" id="profile-5.1.4.2-thing-property-affordance-additional-constraints-8">
+                  <code>uriVariables</code> MUST
+                  NOT be used.
+                  </span>
+                </td>
               </tr>
 
             </tbody>
@@ -1058,11 +1152,13 @@
           <p>
             It is highly RECOMMENDED to always specify a
             <code>unit</code>
-            , if a value has a metric. Authors of <em>Thing
-              Descriptions</em> should be aware, that units
+            , if a value has a metric. 
+            <span class="rfc2119-assertion" id="profile-5.1.4.3-thing-properties-recommended-practice-1">
+            Authors of <em>Thing Descriptions</em> should be aware, that units
             that are common in their geographic region are
             not globally applicable and may lead to
             misinterpretation with drastic consequences.
+            </span>
           </p>
           <p>
             The field
@@ -1077,9 +1173,12 @@
             <code>hex</code>
             or
             <code>bin</code>
-            , to indicate how the value should be
+            , 
+            <span class="rfc2119-assertion" id="profile-5.1.4.3-thing-properties-recommended-practice-2"> 
+            to indicate how the value should be
             interpreted. It is strongly RECOMMENDED to use
             the values
+            </span>
             <code>hex</code>
             ,
             <code>oct</code>
@@ -1104,8 +1203,10 @@
           <h4>Mandatory fields</h4>
 
           <p>
+            <span class="rfc2119-assertion" id="profile-5.1.5.1-thing-action-affordances-mandatory-fields-1">
             The following fields MUST be contained in an
             action element of an <a>Core Profile</a> compliant TD:
+            </span>
           </p>
           <table class="def">
             <thead>
@@ -1124,16 +1225,24 @@
               <tr>
                 <td>input</td>
                 <td>array of DataSchema</td>
-                <td>all elements of the subclasses
+                <td>
+                  <span class="rfc2119-assertion" id="profile-5.1.5.1-thing-action-affordances-mandatory-fields-2">
+                  all elements of the subclasses
                   objectSchema and dataSchema MUST
-                  only contain simple types.</td>
+                  only contain simple types.
+                  </span>
+                </td>
               </tr>
               <tr>
                 <td>output</td>
                 <td>array of DataSchema</td>
-                <td>all elements of the subclasses
+                <td>
+                  <span class="rfc2119-assertion" id="profile-5.1.5.1-thing-action-affordances-mandatory-fields-3">
+                  all elements of the subclasses
                   objectSchema and dataSchema MUST
-                  only contain simple types.</td>
+                  only contain simple types.
+                  </span>
+                </td>
               </tr>
             </tbody>
           </table>
@@ -1157,10 +1266,12 @@
           </p>
 
           <p>
+            <span class="rfc2119-assertion" id="profile-5.1.5.2-thing-action-affordance-additional-constraints-1">
             The following additional constraints MUST be
             applied to the Interaction Affordances of a <a>Thing
               Description</a> conforming to the <a>Core
               Data Model</a>:
+            </span>
           </p>
           <table class="def">
             <thead>
@@ -1174,33 +1285,46 @@
               <tr>
                 <td>forms</td>
                 <td>array of Forms</td>
-                <td>The <code>Array of Form</code>
+                <td>
+                  <span class="rfc2119-assertion" id="profile-5.1.5.2-thing-action-affordance-additional-constraints-2">
+                  The <code>Array of Form</code>
                   of each action MUST contain only a <em>single</em>
                   endpoint.
+                  </span>
                 </td>
               </tr>
               <tr>
                 <td>format</td>
                 <td>string</td>
-                <td>If the field <code>format</code>
+                <td>
+                  <span class="rfc2119-assertion" id="profile-5.1.5.2-thing-action-affordance-additional-constraints-3">
+                  If the field <code>format</code>
                   is used, only formats defined in
                   section 7.3.1-7.3.6 of
                   [[JSON-SCHEMA]] MAY be used.
+                  </span>
                 </td>
               </tr>
               <tr>
                 <td>oneOf</td>
                 <td>string</td>
-                <td>The DataSchema field <code>oneOf</code>
+                <td>
+                  <span class="rfc2119-assertion" id="profile-5.1.5.2-thing-action-affordance-additional-constraints-4">
+                  The DataSchema field <code>oneOf</code>
                   does not make sense for properties
                   and MUST NOT be used.
+                  </span>
                 </td>
               </tr>
               <tr>
                 <td>uriVariables</td>
                 <td>Map of DataSchema</td>
-                <td><code>uriVariables</code> MUST
-                  NOT be used.</td>
+                <td>
+                  <span class="rfc2119-assertion" id="profile-5.1.5.2-thing-action-affordance-additional-constraints-5">
+                  <code>uriVariables</code> MUST
+                  NOT be used.
+                  </span>
+                </td>
               </tr>
             </tbody>
           </table>
@@ -1230,8 +1354,10 @@
         class of section 5.3.1.5 of the <a>WoT Thing Description</a> Specification.
 
         <p>
+          <span class="rfc2119-assertion" id="profile-5.1.6-thing-event-affordance-1"> 
           A <a>Thing</a> may provide more than one event
           mechanism to enable a variety of consumers.
+          </span>
         </p>
 
         <section class="ednote">
@@ -1249,8 +1375,10 @@
         <section>
           <h4>Mandatory fields</h4>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.1.6.1-thing-event-affordance-mandatory-fields-1">
             The following fields MUST be present in an event
             element of a <em>Core TD</em>:
+            </span>
           </p>
           <table class="def">
             <thead>
@@ -1286,9 +1414,11 @@
         <section>
           <h4>Additional Constraints</h4>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.1.6.2-thing-event-affordance-additional-constrains-1">
             The following additional constraints MUST be
             applied to the Event Affordances of a <a>WoT Thing
               Description</a> conforming to the profile:
+            </span>
           </p>
           <table class="def">
             <thead>
@@ -1302,16 +1432,23 @@
               <tr>
                 <td>forms</td>
                 <td>array of Forms</td>
-                <td>The <code>Array of Form</code>
+                <td>
+                  <span class="rfc2119-assertion" id="profile-5.1.6.2-thing-event-affordance-additional-constrains-2">
+                  The <code>Array of Form</code>
                   of each event MUST contain only a <em>single</em>
                   endpoint.
+                  </span>
                 </td>
               </tr>
               <tr>
                 <td>uriVariables</td>
                 <td>Map of DataSchema</td>
-                <td><code>uriVariables</code> MUST
-                  NOT be used.</td>
+                <td>
+                  <span class="rfc2119-assertion" id="profile-5.1.6.2-thing-event-affordance-additional-constrains-3">
+                  <code>uriVariables</code> MUST
+                  NOT be used.
+                  </span>
+                </td>
               </tr>
             </tbody>
           </table>
@@ -1324,14 +1461,18 @@
       <section>
         <h3 id="forms">Forms</h3>
         <p>
+          <span class="rfc2119-assertion" id="profile-5.1.7-thing-forms-1"> 
           A <a>Thing</a> may provide more than one event
           mechanism to enable a variety of consumers.
+          </span>
         </p>
         <section>
           <h4>Mandatory fields</h4>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.1.7.1-thing-forms-mandatory-fields-1">
             The following fields MUST be present in a form
             element of a <em>Core TD</em>:
+          </span>
           </p>
           <table class="def">
             <thead>
@@ -1367,10 +1508,12 @@
         <section>
           <h4>Additional Constraints</h4>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.1.7.2-thing-forms-additional-constraints-1">
             The following additional constraints MUST be
             applied to the Form elements of a <a>WoT Thing
               Description</a> conforming to the <a>Core
               profile</a>:
+            </span>
           </p>
           <table class="def">
             <thead>
@@ -1384,14 +1527,22 @@
               <tr>
                 <td>security</td>
                 <td>string or Array of string</td>
-                <td><code>security</code> at form
-                  level MUST NOT be used.</td>
+                <td>
+                  <span class="rfc2119-assertion" id="profile-5.1.7.2-thing-forms-additional-constraints-2">
+                  <code>security</code> at form
+                  level MUST NOT be used.
+                  </span>
+                </td>
               </tr>
               <tr>
                 <td>scopes</td>
                 <td>string or Array of string</td>
-                <td><code>scopes</code> MUST NOT be
-                  used.</td>
+                <td>
+                  <span class="rfc2119-assertion" id="profile-5.1.7.2-thing-forms-additional-constraints-3">
+                  <code>scopes</code> MUST NOT be
+                  used.
+                  </span>
+                </td>
               </tr>
             </tbody>
           </table>
@@ -1420,20 +1571,29 @@
       <section>
         <h3 id="security">Security</h3>
         <p>
+          <span class="rfc2119-assertion" id="profile-5.1.9-thing-security-1">
           The <a>Core Data Model</a> defines a subset of the
           security schemes that MAY be implemented on resource
-          constrained devices. A security scheme MUST be
-          defined at the thing level. The security scheme is
+          constrained devices. 
+          </span>
+          <span class="rfc2119-assertion" id="profile-5.1.9-thing-security-2">
+          A security scheme MUST be
+          defined at the thing level.
+          </span>
+          <span class="rfc2119-assertion" id="profile-5.1.9-thing-security-3">
+          The security scheme is
           applied to the thing as a whole, a thing may adopt
           multiple security schemes.
+          </span>
         </p>
         <p>
           The set of security schemes supported in the <a>Core
-            Data Model</a> is based on the PlugFest results. To
-          ensure interoperability, a TD consumer, which
-          compliant with the <a>Core Data Model</a> MUST
-          support <strong>all</strong> of the following
-          security schemes:
+            Data Model</a> is based on the PlugFest results.
+            <span class="rfc2119-assertion" id="profile-5.1.9-thing-security-4">
+              To ensure interoperability, a TD consumer, which 
+              compliant with the <a>Core Data Model</a> MUST 
+              support <strong>all</strong> of the following security schemes:
+            </span>
         </p>
 
         <ul>
@@ -1465,14 +1625,17 @@
         the HTTP [[HTTP11]] protocol.
       </p>
       <p>
+        <span class="rfc2119-assertion" id="profile-5.2-thing-protocol-binding-1">
         A Consumer or Web Thing conforming to the WoT Core Profile
         MUST implement this protocol binding.
+        </span>
       </p>
       <section id="properties">
         <h4>Properties</h4>
         <section id="readproperty">
           <h5><code>readproperty</code></h5>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.2.1.1-thing-protocol-binding-properties-readproperty-1">
             The URL of a <code>Property</code> resource to be used when reading
             the value of a property MUST be obtained from a Canonical TD by
             locating a
@@ -1485,10 +1648,13 @@
             <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
             scheme</a> [[RFC3986]] of the value of its <code>href</code> member
             is <code>http</code> or <code>https</code>.
+            </span>
           </p>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.2.1.1-thing-protocol-binding-properties-readproperty-2">
             In order to read the value of a property, a Consumer MUST send
             an HTTP request to a Web Thing with:
+            </span>
             <ul>
               <li>Method set to <code>GET</code></li>
               <li>URL set to the URL of the <code>Property</code> resource</li>
@@ -1502,10 +1668,12 @@
           Accept: application/json
           </pre>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.2.1.1-thing-protocol-binding-properties-readproperty-3">
             If a Web Thing receives an HTTP request following the format
             above and the Consumer has permission to read the corresponding
             property, then upon successfully reading the value of the property
             it MUST send an HTTP response with:
+            </span>
             <ul>
               <li>Status code set to <code>200</code></li>
               <li><code>Content-Type</code> header set to <code>application/json
@@ -1522,6 +1690,7 @@
         <section id="writeproperty">
           <h5><code>writeproperty</code></h5>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.2.1.2-thing-protocol-binding-properties-writeproperty-1">
             The URL of a <code>Property</code> resource to be used when writing
             the value of a property MUST be obtained from a Canonical TD by
             locating a
@@ -1534,9 +1703,13 @@
             <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
             scheme</a> [[RFC3986]] of the value of its <code>href</code> member
             is <code>http</code> or <code>https</code>.
+            </span>
           </p>
-          <p>In order to write the value of a property, a Consumer MUST send
+          <p>
+            <span class="rfc2119-assertion" id="profile-5.2.1.2-thing-protocol-binding-properties-writeproperty-2">
+            In order to write the value of a property, a Consumer MUST send
             an HTTP request to a Web Thing with:
+            </span>
             <ul>
               <li>Method set to <code>PUT</code></li>
               <li>URL set to the URL of the <code>Property</code> resource</li>
@@ -1556,10 +1729,12 @@
           true
           </pre>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.2.1.2-thing-protocol-binding-properties-writeproperty-3">
             If a Web Thing receives an HTTP request following the format
             above and the Consumer has permission to write the corresponding
             property, then upon successfully writing the value of the
             property it MUST send an HTTP response with:
+            </span>
             <ul>
               <li>Status code set to <code>204</code></li>
             </ul>
@@ -1571,6 +1746,7 @@
         <section id="readallproperties">
           <h5><code>readallproperties</code></h5>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.2.1.3-thing-protocol-binding-properties-readallproperties-1">
             The URL of a <code>Properties</code> resource to be used when
             reading the value of all properties at once MUST be obtained from a
             Canonical TD by locating a
@@ -1583,10 +1759,13 @@
             <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
             scheme</a> [[RFC3986]] of the value of its <code>href</code> member
             is <code>http</code> or <code>https</code>.
+            </span>
           </p>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.2.1.3-thing-protocol-binding-properties-readallproperties-2">
             In order to read the value of all properties, a Consumer MUST send
             an HTTP request to a Web Thing with:
+            </span>
             <ul>
               <li>Method set to <code>GET</code></li>
               <li>URL set to the URL of the <code>Properties</code> resource
@@ -1601,10 +1780,12 @@
           Accept: application/json
           </pre>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.2.1.3-thing-protocol-binding-properties-readallpropertis-3">
             If a Web Thing receives an HTTP request following the format
             above, then upon successfully reading the values of all the
             readable properties to which the Consumer has permission to
             access, it MUST send an HTTP response with:
+            </span>
             <ul>
               <li>Status code set to <code>200</code></li>
               <li><code>Content-Type</code> header set to <code>application/json
@@ -1625,6 +1806,7 @@
         <section id="writemultipleproperties">
           <h5><code>writemultipleproperties</code></h5>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.2.1.4-thing-protocol-binding-properties-writemultipleproperties-1">
             The URL of a <code>Properties</code> resource to be used when
             writing the value of multiple properties at once MUST be obtained
             from a Canonical TD by locating a
@@ -1637,10 +1819,13 @@
             <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
             scheme</a> [[RFC3986]] of the value of its <code>href</code> member
             is <code>http</code> or <code>https</code>.
+            </span>
           </p>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.2.1.4-thing-protocol-binding-properties-writemultipleproperties-2">
             In order to write the value of multiple properties at once, a
             Consumer MUST send an HTTP request to a Web Thing with:
+            </span>
             <ul>
               <li>Method set to <code>PUT</code></li>
               <li>URL set to the URL of the <code>Properties</code> resource
@@ -1664,9 +1849,11 @@
           }
           </pre>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.2.1.4-thing-protocol-binding-properties-writemultipleproperties-3">
             If a Web Thing receives an HTTP request following the format
             above, then upon successfully writing the values of the requested
             writable properties it MUST send an HTTP response with:
+            </span>
             <ul>
               <li>Status code set to <code>204</code></li>
             </ul>
@@ -1701,6 +1888,7 @@
         <section id="invokeaction">
           <h5><code>invokeaction</code></h5>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.2.2.1-thing-protocol-binding-actions-invokeaction-1">
             The URL of an <code>Action</code> resource to be used when invoking
             an action MUST be obtained from a Canonical TD by locating a
             <a href="https://www.w3.org/TR/wot-thing-description/#form">
@@ -1712,9 +1900,13 @@
             <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
             scheme</a> [[RFC3986]] of the value of its <code>href</code> member
             is <code>http</code> or <code>https</code>.
+            </span>
           </p>
-          <p>In order to invoke an action on a Web Thing, a Consumer MUST send
+          <p>
+            <span class="rfc2119-assertion" id="profile-5.2.2.1-thing-protocol-binding-actions-invokeaction-2">
+            In order to invoke an action on a Web Thing, a Consumer MUST send
             an HTTP request to the Web Thing with:
+            </span>
             <ul>
               <li>Method set to <code>POST</code></li>
               <li>URL set to the URL of the <code>Action</code> resource</li>
@@ -1737,17 +1929,22 @@
           }
           </pre>
           <p>
+            <span class="rfc2119-assertion" id="profile-5.2.2.1-thing-protocol-binding-actions-invokeaction-3">
             If a Web Thing receives an HTTP request following the format
             above and the Consumer has permission to invoke the corresponding
             action, then upon successfully invoking the action it MUST send an
             HTTP response with:
+            </span>
           </p>
-          <p class="ednote">The response to invoking an action needs to
-            be defined. Given not all actions can be completed within the
+          <p class="ednote">
+            The response to invoking an action needs to be defined. 
+            <span class="rfc2119-assertion" id="profile-5.2.2.1-thing-protocol-binding-actions-invokeaction-4">
+            Given not all actions can be completed within the
             timeout period of an HTTP response, this may need to include a
             reference to an action request resource in an action queue (see
             <a href="https://github.com/w3c/wot-thing-description/issues/302">
             #302</a>).
+            </span>
           </p>
         </section>
         <section class="ednote">Other operations under consideration include
@@ -1795,10 +1992,12 @@
       <section id="error-responses">
         <h4>Error Responses</h4>
         <p>
+          <span class="rfc2119-assertion" id="profile-5.2.4-thing-protocol-binding-error-responses-1">
           If any of the operations defined above are unsuccessful then
           the Web Thing MUST send an HTTP response with an HTTP error code which
           describes the reason for the failure. It is RECOMMENDED that error
           responses use one of the following HTTP error codes:
+          </span>
         </p>
         <ul>
           <li><code>400 Bad Request</code></li>
@@ -1808,19 +2007,27 @@
           <li><code>500 Internal Server Error</code></li>
         </ul>
         <p>
+          <span class="rfc2119-assertion" id="profile-5.2.4-thing-protocol-binding-error-responses-2">
           Web Things MAY respond with other valid HTTP error codes
-          (e.g. <code>418 I'm a teapot</code>), but Consumers MAY interpret
-          those error codes as a generic <code>4xx</code> or <code>5xx</code>
+          (e.g. <code>418 I'm a teapot</code>), 
+          </span>
+          <span class="rfc2119-assertion" id="profile-5.2.4-thing-protocol-binding-error-responses-3">
+          but Consumers MAY interpret those error codes as a generic <code>4xx</code> or <code>5xx</code>
           error with no special defined behaviour.
+          </span>
         </p>
         <p class="ednote">
+          <span class="rfc2119-assertion" id="profile-5.2.4-thing-protocol-binding-error-responses-3"> 
           If we define the finite set of error responses as above then we
           should also define what a Consumer should do if it receives a 3xx
           redirect type response.
+          </span>
         </p>
         <p>
+          <span class="rfc2119-assertion" id="profile-5.2.4-thing-protocol-binding-error-responses-4">
           If an HTTP error response contains a body, the content of that body
           MUST conform with with the Problem Details format [[RFC7807]].
+          </span>
         </p>
       </section>
     </section>
@@ -1829,10 +2036,14 @@
     <section id="external-representation">
       <h2 id="external-td-representations">External TD
         representations</h2>
-      <p>The default representation is JSON. Semantic
+      <p>
+        <span class="rfc2119-assertion" id="profile-5.3-exteanal-td-representations-1"> 
+        The default representation is JSON. Semantic
         annotations based on JSON-LD MAY be present but are not
         required to perform all interactions with the thing
-        instance.</p>
+        instance.
+        </span>
+      </p>
 
         <section id="canonical-representation">
           <h2 id="canonical-td-representations">Canonical TD


### PR DESCRIPTION
I added css mark "&lt;span&gt;" into index.html.

The additional method is as follows.

1. "&lt;span&gt;" is added to sentences that there are "MUST", "MAY","SHOULD".
2. " id" is "chapter number" + "chapter name".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/pull/82.html" title="Last updated on Jun 22, 2021, 6:54 AM UTC (1bba706)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/82/fd386c5...1bba706.html" title="Last updated on Jun 22, 2021, 6:54 AM UTC (1bba706)">Diff</a>