### PR TITLE
Fixed the mistake on second line in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US"
+<html lang="en-US">
 
 <head>
   <meta charset="utf-8" />

--- a/index.html
+++ b/index.html
@@ -2017,14 +2017,14 @@
           </span>
         </p>
         <p class="ednote">
-          <span class="rfc2119-assertion" id="profile-5.2.4-thing-protocol-binding-error-responses-3"> 
+          <span class="rfc2119-assertion" id="profile-5.2.4-thing-protocol-binding-error-responses-4"> 
           If we define the finite set of error responses as above then we
           should also define what a Consumer should do if it receives a 3xx
           redirect type response.
           </span>
         </p>
         <p>
-          <span class="rfc2119-assertion" id="profile-5.2.4-thing-protocol-binding-error-responses-4">
+          <span class="rfc2119-assertion" id="profile-5.2.4-thing-protocol-binding-error-responses-5">
           If an HTTP error response contains a body, the content of that body
           MUST conform with with the Problem Details format [[RFC7807]].
           </span>


### PR DESCRIPTION
There was an issue on second line of index.html. So I fixed it as follows.

<html lang="en-US"      -->        <html lang="en-US">

thank you.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/pull/83.html" title="Last updated on Jun 23, 2021, 6:50 AM UTC (1c6a830)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/83/1580311...1c6a830.html" title="Last updated on Jun 23, 2021, 6:50 AM UTC (1c6a830)">Diff</a>