### PR TITLE
Adding paragraph on transport encoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -1525,22 +1525,6 @@
         MUST implement this protocol binding.
         </span>
       </p>
-
-
-      All API access : over HTTPS
-
-
-      • HTTP : HTTP/1.1
-      • Content-Type : application/json
-      • Unicode : UTF-8
-      • Use of HTTPS
-      • Date and time formats : RFC 3339 (ISO 8601)
-      e.g., 2018-01-02T12:34:56+09:00
-      The format of date (yyyy, mm, dd), hours, minutes and seconds should
-      be followed as particular case.
-      • Naming convention: lower camel case for property names.
-
-
       <section id="properties">
         <h4>Properties</h4>
         <section id="readproperty">

--- a/index.html
+++ b/index.html
@@ -1525,6 +1525,22 @@
         MUST implement this protocol binding.
         </span>
       </p>
+
+
+      All API access : over HTTPS
+
+
+      • HTTP : HTTP/1.1
+      • Content-Type : application/json
+      • Unicode : UTF-8
+      • Use of HTTPS
+      • Date and time formats : RFC 3339 (ISO 8601)
+      e.g., 2018-01-02T12:34:56+09:00
+      The format of date (yyyy, mm, dd), hours, minutes and seconds should
+      be followed as particular case.
+      • Naming convention: lower camel case for property names.
+
+
       <section id="properties">
         <h4>Properties</h4>
         <section id="readproperty">
@@ -1925,14 +1941,17 @@
           </span>
         </p>
       </section>
-    </section>
+      </section>
+
+
+
 
     <!-- External Representation -->
     <section id="external-representation">
       <h2 id="external-td-representations">External TD
         representations</h2>
       <p>
-        <span class="rfc2119-assertion" id="profile-5.3-exteanal-td-representations-1">
+        <span class="rfc2119-assertion" id="profile-5.3-external-td-representations-1">
         The default representation is JSON. Semantic
         annotations based on JSON-LD MAY be present but are not
         required to perform all interactions with the thing
@@ -1940,22 +1959,35 @@
         </span>
       </p>
 
-        <section id="canonical-representation">
-          <h2 id="canonical-td-representations">Canonical TD
-            representation</h2>
-          <p>
-            A canonical representation serves multiple purposes.
-            It is simplifying the parsing process, enables to identify
-            equivalent TDs by simple string comparisons.
-            Furthermore it allows the use of a simple signing mechanism,
-            such as <a href="https://w3c-ccg.github.io/ld-proofs/">Linked Data Proofs</a> or JSON Web Signatures [[RFC7515]] and enables
-            identity checks on encrypted TDs.
-          </p>
-	  <p>
-	     The canonical JSON representation format of a TD adopts the JSON Canonicalization Scheme (JCS) defined by
-	     <a href="https://tools.ietf.org/html/rfc8785>RFC-8785</a> including errata <a href="https://www.rfc-editor.org/errata/eid6292">6292</a>.
-	  </p>
-      </section>
+      <h3 id="character encoding">Character Encoding</h3>
+      <p>
+        <span class="rfc2119-assertion" id="profile-5.3.1-external-td-representations-2">
+        To provide interoperability and in alignment with the latest version 
+        of the JSON standard [[rfc8259]],
+        the JSON representation of a thing description MUST be encoded using UTF-8 [[RFC3629]].   
+        </span>       
+      </p>
+
+    </p>
+    <h3 id="canonical-td-representations">Canonical TD
+      representation</h3>
+    <p>
+      A canonical representation serves multiple purposes.
+      It is simplifying the parsing process, enables to identify
+      equivalent TDs by simple string comparisons.
+      Furthermore it allows the use of a simple signing mechanism,
+      such as <a href="https://w3c-ccg.github.io/ld-proofs/">Linked Data Proofs</a> or JSON Web Signatures [[RFC7515]] and
+      enables
+      identity checks on encrypted TDs.
+    </p>
+    <p>
+      The canonical JSON representation format of a TD adopts the JSON Canonicalization Scheme (JCS) defined by
+      <a href="https://tools.ietf.org/html/rfc8785>RFC-8785</a> including errata <a href="
+        https://www.rfc-editor.org/errata/eid6292">6292</a>.
+    </p>
+ 
+ 
+       
 
 
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/pull/86.html" title="Last updated on Jul 15, 2021, 6:40 AM UTC (ac4a244)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/86/f1ec8e2...ac4a244.html" title="Last updated on Jul 15, 2021, 6:40 AM UTC (ac4a244)">Diff</a>