### PR TITLE
Define protocol binding for events - closes #42

### DIFF
--- a/index.html
+++ b/index.html
@@ -1851,9 +1851,18 @@
           </a>).
         </section>
       </section>
+
       <section id="events">
         <h4>Events</h4>
-
+        <p>
+          The Core Profile uses Server-Sent Events [[EVENTSOURCE]] as a
+          mechanism for Consumers to subscribe to events emitted by a Web Thing.
+          Any <code>Form</code> within an <code>Event</code> affordance whose 
+          <code>href</code> member contains a URI with a URI scheme of 
+          <code>http</code> or <code>https</code> is assumed to have a 
+          <code>subprotocol</code> of <code>sse</code>, unless specified
+          otherwise.
+        </p>
         <section id="subscribeevent">
           <h5><code>subscribeevent</code></h5>
           <p class="rfc2119-assertion" 
@@ -1944,10 +1953,14 @@
             <code>data</code> field with event data, if any. The 
             event data MUST follow the data schema specified in the
             <code>EventAffordance</code> and MUST be serialized in JSON.
+            The <code>id</code> field SHOULD be set to a unique identifier for 
+            the event, for use when re-establishing a dropped connection (see 
+            below).
           </p>
           <pre class="example">
-            event: "overheated"
-            data: 90
+            event: overheated\n
+            data: 90\n
+            id: 12345\n\n
           </pre>
           <p class="rfc2119-assertion" 
           id="core-profile-protocol-binding-events-subscribeevent-5">
@@ -2069,10 +2082,14 @@
             <code>data</code> field with event data, if any. The 
             event data MUST follow the data schema specified in the
             <code>EventAffordance</code> and MUST be serialized in JSON.
+            The <code>id</code> field SHOULD be set to a unique identifier for 
+            the event, for use when re-establishing a dropped connection (see 
+            below).
           </p>
           <pre class="example">
-            event: "overheated"
-            data: 90
+            event: overheated\n
+            data: 90\n
+            id: 12345\n\n
           </pre>
           <p class="rfc2119-assertion" 
           id="core-profile-protocol-binding-events-subscribeallevents-5">

--- a/index.html
+++ b/index.html
@@ -89,7 +89,14 @@
           date: "2008-07",
           publisher: "ISO"
         },
-
+        "EVENTSOURCE": {
+          title: "Server-Sent Events",
+          href: "https://html.spec.whatwg.org/multipage/server-sent-events.html",
+          authors: ["Ian Hickson"],
+          status: "Living Standard",
+          publisher: "WHATWG",
+          date: "30 July 2021"
+        }
       }
     };
   </script>
@@ -1857,32 +1864,35 @@
         <p>
           The Core Profile uses Server-Sent Events [[EVENTSOURCE]] as a
           mechanism for Consumers to subscribe to events emitted by a Web Thing.
-          Any <code>Form</code> within an <code>Event</code> affordance whose 
-          <code>href</code> member contains a URI with a URI scheme of 
-          <code>http</code> or <code>https</code> is assumed to have a 
-          <code>subprotocol</code> of <code>sse</code>, unless specified
-          otherwise.
         </p>
         <section id="subscribeevent">
           <h5><code>subscribeevent</code></h5>
           <p class="rfc2119-assertion" 
             id="core-profile-protocol-binding-events-subscribeevent-1">
             The URL of an <code>Event</code> resource to be used when 
-            subscribing to an event MUST be obtained from a Canonical TD by
-            locating a
+            subscribing to an event MUST be obtained from a Thing Description 
+            by locating a 
             <a href="https://www.w3.org/TR/wot-thing-description/#form">
-            <code>Form</code></a> inside the corresponding
+            <code>Form</code></a> inside the corresponding 
             <a href="https://www.w3.org/TR/wot-thing-description/#eventaffordance">
-            <code>EventAffordance</code></a>
-            for which the value of its <code>op</code> member is
-            <code>subscribeevent</code> and the
-            <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
-            scheme</a> [[RFC3986]] of the value of its <code>href</code> member
-            is <code>http</code> or <code>https</code>.
-            If multiple <code>Form</code>s meet these criteria but one 
-            <code>Form</code> has a <code>subprotocol</code> member with a value 
-            of <code>"sse"</code> then that <code>Form</code> SHOULD be used.
+            <code>EventAffordance</code></a> for which:
+            <ul>
+              <li>
+                After defaults have been applied, the value of its 
+                <code>op</code> member is <code>subscribeevent</code>
+              </li>
+              <li>
+                After being resolved against a base URL where applicable, the
+                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                scheme</a> [[RFC3986]] of the value of its <code>href</code>
+                member is <code>http</code> or <code>https</code>
+              </li>
+              <li>Its <code>subprotocol</code> member has a value of
+                <code>"sse"</code>
+              </li>
+            </ul>
           </p>
+            
           <p class="rfc2119-assertion" 
             id="core-profile-protocol-binding-events-subscribeevent-2">
             In order to subscribe to an event, a Consumer MUST follow the 
@@ -1911,9 +1921,12 @@
           Connection: keep-alive
           </pre>
           <p class="note" title="Opening a connection using JavaScript">
-            A Server-Sent Events connection can be initiated in JavaScript 
-            [[ECMASCRIPT]] using an <code>EventSource</code> 
-            [[EVENTSOURCE]] object.
+            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed 
+            in a runtime which exposes the
+            <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface">
+            <code>EventSource</code></a> interface, a Server-Sent Events 
+            connection can be initiated using the <code>EventSource</code>
+            constructor.
             <pre class="example">
               const overheatedEventSource = new EventSource('/things/lamp/events/overheated');
             </pre>
@@ -1985,9 +1998,12 @@
             [[EVENTSOURCE]].
           </p>
           <p class="note" title="Terminating a connection using JavaScript">
-            A Server-Sent Events connection can be terminated in JavaScript 
-            [[ECMASCRIPT]] using the <code>close()</code> method on an 
-            <code>EventSource</code> [[EVENTSOURCE]] object.
+            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed 
+            in a runtime which exposes the
+            <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface">
+            <code>EventSource</code></a> interface, a Server-Sent Events 
+            connection can be terminated using the <code>close()</code> method 
+            on an <code>EventSource</code> [[EVENTSOURCE]] object.
             <pre class="example">
               overheatedEventSource.close();
             </pre>
@@ -1998,20 +2014,28 @@
           <h5><code>subscribeallevents</code></h5>
           <p class="rfc2119-assertion" 
             id="core-profile-protocol-binding-events-subscribeallevents-1">
-            The URL of a resource to be used when subscribing to all events 
-            emitted by a Web Thing MUST be obtained from a Canonical TD by
-            locating a
+            The URL of an events resource to be used when subscribing to all
+            events emitted by a Web Thing MUST be obtained from a Thing
+            Description by locating a 
             <a href="https://www.w3.org/TR/wot-thing-description/#form">
             <code>Form</code></a> inside the top level 
             <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json"><code>forms</code></a>
-            member of a Thing Description for which the value of its 
-            <code>op</code> member is <code>subscribeallevents</code> and the
-            <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
-            scheme</a> [[RFC3986]] of the value of its <code>href</code> member
-            is <code>http</code> or <code>https</code>.
-            If multiple <code>Form</code>s meet these criteria but one 
-            <code>Form</code> has a <code>subprotocol</code> member with a value 
-            of <code>"sse"</code> then that <code>Form</code> SHOULD be used.
+            member of a Thing Description for which:
+            <ul>
+              <li>
+                The value of its <code>op</code> member is 
+                <code>subscribeallevents</code>
+              </li>
+              <li>
+                After being resolved against a base URL where applicable, the
+                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                scheme</a> [[RFC3986]] of the value of its <code>href</code>
+                member is <code>http</code> or <code>https</code>
+              </li>
+              <li>Its <code>subprotocol</code> member has a value of
+                <code>"sse"</code>
+              </li>
+            </ul>
           </p>
           <p class="rfc2119-assertion" 
             id="core-profile-protocol-binding-events-subscribeallevents-2">
@@ -2041,9 +2065,12 @@
             Connection: keep-alive
           </pre>
           <p class="note" title="Opening a connection using JavaScript">
-            A Server-Sent Events connection can be initiated in JavaScript 
-            [[ECMASCRIPT]] using an <code>EventSource</code> 
-            [[EVENTSOURCE]] object.
+            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed 
+            in a runtime which exposes the
+            <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface">
+            <code>EventSource</code></a> interface, a Server-Sent Events 
+            connection can be initiated using the <code>EventSource</code>
+            constructor.
             <pre class="example">
               const lampEventsSource = new EventSource('/things/lamp/events');
             </pre>
@@ -2114,9 +2141,12 @@
             Server-Sent Events specification [[EVENTSOURCE]].
           </p>
           <p class="note" title="Terminating a connection using JavaScript">
-            A Server-Sent Events connection can be terminated in JavaScript 
-            [[ECMASCRIPT]] using the <code>close()</code> method on an 
-            <code>EventSource</code> [[EVENTSOURCE]] object.
+            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed 
+            in a runtime which exposes the
+            <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface">
+            <code>EventSource</code></a> interface, a Server-Sent Events 
+            connection can be terminated using the <code>close()</code> method 
+            on an <code>EventSource</code> [[EVENTSOURCE]] object.
             <pre class="example">
               lampEventsSource.close();
             </pre>

--- a/index.html
+++ b/index.html
@@ -88,14 +88,6 @@
           status: "Published",
           date: "2008-07",
           publisher: "ISO"
-        },
-        "EVENTSOURCE": {
-          title: "Server-Sent Events",
-          href: "https://html.spec.whatwg.org/multipage/server-sent-events.html",
-          authors: ["Ian Hickson"],
-          status: "Living Standard",
-          publisher: "WHATWG",
-          date: "30 July 2021"
         }
       }
     };

--- a/index.html
+++ b/index.html
@@ -1880,8 +1880,8 @@
           <ul class="rfc2119-assertion" 
             id="core-profile-protocol-binding-events-subscribeevent-2">
             <li>
-              After defaults have been applied, the value of its 
-              <code>op</code> member is <code>subscribeevent</code>
+              After defaults have been applied, its <code>op</code> member 
+              contains the value <code>subscribeevent</code>
             </li>
             <li>
               After being resolved against a base URL where applicable, the
@@ -2030,7 +2030,7 @@
           <ul class="rfc2119-assertion" 
             id="core-profile-protocol-binding-events-subscribeallevents-2">
             <li>
-              The value of its <code>op</code> member is 
+              Its <code>op</code> member contains the value 
               <code>subscribeallevents</code>
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -1891,6 +1891,8 @@
                 <code>"sse"</code>
               </li>
             </ul>
+            The resolved value of the <code>href</code> member MUST then be used
+            as the URL of the <code>Event</code> resource.
           </p>
             
           <p class="rfc2119-assertion" 
@@ -2036,6 +2038,8 @@
                 <code>"sse"</code>
               </li>
             </ul>
+            The resolved value of the <code>href</code> member MUST then be used
+            as the URL of the events resource.
           </p>
           <p class="rfc2119-assertion" 
             id="core-profile-protocol-binding-events-subscribeallevents-2">

--- a/index.html
+++ b/index.html
@@ -1876,27 +1876,30 @@
             <code>Form</code></a> inside the corresponding 
             <a href="https://www.w3.org/TR/wot-thing-description/#eventaffordance">
             <code>EventAffordance</code></a> for which:
-            <ul>
-              <li>
-                After defaults have been applied, the value of its 
-                <code>op</code> member is <code>subscribeevent</code>
-              </li>
-              <li>
-                After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
-                scheme</a> [[RFC3986]] of the value of its <code>href</code>
-                member is <code>http</code> or <code>https</code>
-              </li>
-              <li>Its <code>subprotocol</code> member has a value of
-                <code>"sse"</code>
-              </li>
-            </ul>
+          </p>
+          <ul class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-events-subscribeevent-2">
+            <li>
+              After defaults have been applied, the value of its 
+              <code>op</code> member is <code>subscribeevent</code>
+            </li>
+            <li>
+              After being resolved against a base URL where applicable, the
+              <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+              scheme</a> [[RFC3986]] of the value of its <code>href</code>
+              member is <code>http</code> or <code>https</code>
+            </li>
+            <li>Its <code>subprotocol</code> member has a value of
+              <code>"sse"</code>
+            </li>
+          </ul>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-events-subscribeevent-3">
             The resolved value of the <code>href</code> member MUST then be used
             as the URL of the <code>Event</code> resource.
           </p>
-            
           <p class="rfc2119-assertion" 
-            id="core-profile-protocol-binding-events-subscribeevent-2">
+            id="core-profile-protocol-binding-events-subscribeevent-4">
             In order to subscribe to an event, a Consumer MUST follow the 
             Server-Sent Events [[EVENTSOURCE]] specification to open a
             connection with the Web Thing at the URL of the <code>Event</code>
@@ -1905,17 +1908,17 @@
           <p>
             This will usually involve the Consumer sending an HTTP request to
             the Web Thing with:
-            <ul>
-              <li>Method set to <code>GET</code></li>
-              <li>URL set to the URL of the <code>Event</code> resource</li>
-              <li>
-                <code>Accept</code> header set to <code>text/event-stream</code>
-              </li>
-              <li>
-                <code>Connection</code> header set to <code>keep-alive</code>
-              </li>
-            </ul>
           </p>
+          <ul>
+            <li>Method set to <code>GET</code></li>
+            <li>URL set to the URL of the <code>Event</code> resource</li>
+            <li>
+              <code>Accept</code> header set to <code>text/event-stream</code>
+            </li>
+            <li>
+              <code>Connection</code> header set to <code>keep-alive</code>
+            </li>
+          </ul>
           <pre class="example">
           GET /things/lamp/events/overheated HTTP/1.1
           Host: mythingserver.com
@@ -1934,7 +1937,7 @@
             </pre>
           </p>
           <p class="rfc2119-assertion" 
-          id="core-profile-protocol-binding-events-subscribeevent-3">
+            id="core-profile-protocol-binding-events-subscribeevent-5">
             If a Web Thing receives an HTTP request following the format
             above and the Consumer has permission to subscribe to the 
             corresponding event, then it MUST follow the Server-Sent Events 
@@ -1945,20 +1948,20 @@
           <p>
             This will usually involve the Web Thing initially sending an HTTP 
             response to the Consumer with:
-            <ul>
-              <li>Status code set to <code>200</code></li>
-              <li>
-                <code>Content-Type</code> header set to 
-                <code>text/event-stream</code>
-              </li>
-            </ul>
           </p>
+          <ul>
+            <li>Status code set to <code>200</code></li>
+            <li>
+              <code>Content-Type</code> header set to 
+              <code>text/event-stream</code>
+            </li>
+          </ul>
           <pre class="example">
           HTTP/1.1 200 OK
           Content-Type: text/event-stream
           </pre>
           <p class="rfc2119-assertion" 
-            id="core-profile-protocol-binding-events-subscribeevent-4">
+            id="core-profile-protocol-binding-events-subscribeevent-6">
             Whenever an event of the specified type occurs while the Web Thing 
             has an open connection with a Consumer, the Web Thing MUST 
             send event data to the Consumer using the event stream format in the 
@@ -1978,7 +1981,7 @@
             id: 12345\n\n
           </pre>
           <p class="rfc2119-assertion" 
-          id="core-profile-protocol-binding-events-subscribeevent-5">
+            id="core-profile-protocol-binding-events-subscribeevent-7">
             If the connection between the Consumer and Web Thing drops
             (except as a result of the <code>unsubscribe</code> operation 
             defined below), the Consumer MUST re-establish the connection 
@@ -2023,21 +2026,25 @@
             <code>Form</code></a> inside the top level 
             <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json"><code>forms</code></a>
             member of a Thing Description for which:
-            <ul>
-              <li>
-                The value of its <code>op</code> member is 
-                <code>subscribeallevents</code>
-              </li>
-              <li>
-                After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
-                scheme</a> [[RFC3986]] of the value of its <code>href</code>
-                member is <code>http</code> or <code>https</code>
-              </li>
-              <li>Its <code>subprotocol</code> member has a value of
-                <code>"sse"</code>
-              </li>
-            </ul>
+          </p>
+          <ul class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-events-subscribeallevents-2">
+            <li>
+              The value of its <code>op</code> member is 
+              <code>subscribeallevents</code>
+            </li>
+            <li>
+              After being resolved against a base URL where applicable, the
+              <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+              scheme</a> [[RFC3986]] of the value of its <code>href</code>
+              member is <code>http</code> or <code>https</code>
+            </li>
+            <li>Its <code>subprotocol</code> member has a value of
+              <code>"sse"</code>
+            </li>
+          </ul>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-events-subscribeallevents-3">
             The resolved value of the <code>href</code> member MUST then be used
             as the URL of the events resource.
           </p>
@@ -2051,17 +2058,17 @@
           <p>
             This will usually involve the Consumer sending an HTTP request to
             the Web Thing with:
-            <ul>
-              <li>Method set to <code>GET</code></li>
-              <li>URL set to the URL of the events resource</li>
-              <li>
-                <code>Accept</code> header set to <code>text/event-stream</code>
-              </li>
-              <li>
-                <code>Connection</code> header set to <code>keep-alive</code>
-              </li>
-            </ul>
           </p>
+          <ul>
+            <li>Method set to <code>GET</code></li>
+            <li>URL set to the URL of the events resource</li>
+            <li>
+              <code>Accept</code> header set to <code>text/event-stream</code>
+            </li>
+            <li>
+              <code>Connection</code> header set to <code>keep-alive</code>
+            </li>
+          </ul>
           <pre class="example">
             GET /things/lamp/events HTTP/1.1
             Host: mythingserver.com
@@ -2090,14 +2097,14 @@
           <p>
             This will usually involve the Web Thing initially sending an HTTP 
             response to the Consumer with:
-            <ul>
-              <li>Status code set to <code>200</code></li>
-              <li>
-                <code>Content-Type</code> header set to 
-                <code>text/event-stream</code>
-              </li>
-            </ul>
           </p>
+          <ul>
+            <li>Status code set to <code>200</code></li>
+            <li>
+              <code>Content-Type</code> header set to 
+              <code>text/event-stream</code>
+            </li>
+          </ul>
           <pre class="example">
             HTTP/1.1 200 OK
             Content-Type: text/event-stream
@@ -2123,7 +2130,7 @@
             id: 12345\n\n
           </pre>
           <p class="rfc2119-assertion" 
-          id="core-profile-protocol-binding-events-subscribeallevents-5">
+            id="core-profile-protocol-binding-events-subscribeallevents-5">
             If the connection between the Consumer and Web Thing drops
             (except as a result of the <code>unsubscribeallevents</code>
             operation defined below), the Consumer MUST re-establish the

--- a/index.html
+++ b/index.html
@@ -1857,6 +1857,14 @@
           The Core Profile uses Server-Sent Events [[EVENTSOURCE]] as a
           mechanism for Consumers to subscribe to events emitted by a Web Thing.
         </p>
+        <p class="note">
+          Consumers are not required to implement the 
+          <a href="https://www.w3.org/TR/eventsource/#the-eventsource-interface">
+          <code>EventSource</code>
+          JavaScript API</a> from the Server-Sent Events
+          specification in order to conform with this profile. Any programming
+          language may be used to consume an event stream.
+        </p>
         <section id="subscribeevent">
           <h5><code>subscribeevent</code></h5>
           <p class="rfc2119-assertion" 

--- a/index.html
+++ b/index.html
@@ -1853,37 +1853,260 @@
       </section>
       <section id="events">
         <h4>Events</h4>
-        <section class="ednote">
-          <p>
-            Other operations under consideration include
-            <code>subscribeevent</code>, <code>unsubscribeevent</code>,
-            <code>subscribeallevents</code>, <code>unsubscribeallevents</code>,
-            <code>readpastevents</code> and <code>readallpastevents</code>.
+
+        <section id="subscribeevent">
+          <h5><code>subscribeevent</code></h5>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-events-subscribeevent-1">
+            The URL of an <code>Event</code> resource to be used when 
+            subscribing to an event MUST be obtained from a Canonical TD by
+            locating a
+            <a href="https://www.w3.org/TR/wot-thing-description/#form">
+            <code>Form</code></a> inside the corresponding
+            <a href="https://www.w3.org/TR/wot-thing-description/#eventaffordance">
+            <code>EventAffordance</code></a>
+            for which the value of its <code>op</code> member is
+            <code>subscribeevent</code> and the
+            <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+            scheme</a> [[RFC3986]] of the value of its <code>href</code> member
+            is <code>http</code> or <code>https</code>.
+            If multiple <code>Form</code>s meet these criteria but one 
+            <code>Form</code> has a <code>subprotocol</code> member with a value 
+            of <code>"sse"</code> then that <code>Form</code> SHOULD be used.
+          </p>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-events-subscribeevent-2">
+            In order to subscribe to an event, a Consumer MUST follow the 
+            Server-Sent Events [[EVENTSOURCE]] specification to open a
+            connection with the Web Thing at the URL of the <code>Event</code>
+            resource.
           </p>
           <p>
-            <code>subscribeevent</code>, <code>unsubscribeevent</code>,
-            <code>subscribeallevents</code> and
-            <code>unsubscribeallevents</code> would require consensus on a
-            default event subscription mechanism for HTTP (e.g. Server Sent
-            Events or WebSockets).
+            This will usually involve the Consumer sending an HTTP request to
+            the Web Thing with:
+            <ul>
+              <li>Method set to <code>GET</code></li>
+              <li>URL set to the URL of the <code>Event</code> resource</li>
+              <li>
+                <code>Accept</code> header set to <code>text/event-stream</code>
+              </li>
+              <li>
+                <code>Connection</code> header set to <code>keep-alive</code>
+              </li>
+            </ul>
+          </p>
+          <pre class="example">
+          GET /things/lamp/events/overheated HTTP/1.1
+          Host: mythingserver.com
+          Accept: text/event-stream
+          Connection: keep-alive
+          </pre>
+          <p class="note" title="Opening a connection using JavaScript">
+            A Server-Sent Events connection can be initiated in JavaScript 
+            [[ECMASCRIPT]] using an <code>EventSource</code> 
+            [[EVENTSOURCE]] object.
+            <pre class="example">
+              const overheatedEventSource = new EventSource('/things/lamp/events/overheated');
+            </pre>
+          </p>
+          <p class="rfc2119-assertion" 
+          id="core-profile-protocol-binding-events-subscribeevent-3">
+            If a Web Thing receives an HTTP request following the format
+            above and the Consumer has permission to subscribe to the 
+            corresponding event, then it MUST follow the Server-Sent Events 
+            [[EVENTSOURCE]] specification to maintain an open connection with 
+            the Consumer and push event data to the Consumer as events of the 
+            specified type are emitted.
           </p>
           <p>
-            <code>subscribeallevents</code> and
-            <code>unsubscribeallevents</code> do not yet exist in the WoT Thing
-            Description specification (see
-            <a href="https://github.com/w3c/wot-thing-description/issues/1082">
-              #1082
-            </a>).
+            This will usually involve the Web Thing initially sending an HTTP 
+            response to the Consumer with:
+            <ul>
+              <li>Status code set to <code>200</code></li>
+              <li>
+                <code>Content-Type</code> header set to 
+                <code>text/event-stream</code>
+              </li>
+            </ul>
+          </p>
+          <pre class="example">
+          HTTP/1.1 200 OK
+          Content-Type: text/event-stream
+          </pre>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-events-subscribeevent-4">
+            Whenever an event of the specified type occurs while the Web Thing 
+            has an open connection with a Consumer, the Web Thing MUST 
+            send event data to the Consumer using the event stream format in the 
+            Server-Sent Events [[EVENTSOURCE]] specification. For each message 
+            sent, the Web Thing MUST set the <code>event</code> field to the 
+            name of the <code>EventAffordance</code> and populate the 
+            <code>data</code> field with event data, if any. The 
+            event data MUST follow the data schema specified in the
+            <code>EventAffordance</code> and MUST be serialized in JSON.
+          </p>
+          <pre class="example">
+            event: "overheated"
+            data: 90
+          </pre>
+          <p class="rfc2119-assertion" 
+          id="core-profile-protocol-binding-events-subscribeevent-5">
+            If the connection between the Consumer and Web Thing drops
+            (except as a result of the <code>unsubscribe</code> operation 
+            defined below), the Consumer MUST re-establish the connection 
+            following the steps outlined in the Server-Sent Events specification
+            [[EVENTSOURCE]]. Once the connection is re-established the Web Thing
+            SHOULD, if possible, send any missed events which occured since
+            the last event specified by the Consumer in a 
+            <code>Last-Event-ID</code> header.
+          </p>
+        </section>
+
+        <section id="unsubscribeevent">
+          <h5><code>unsubscribeevent</code></h5>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-events-unsubscribeevent-1">
+            In order to unsubscribe from an event, a Consumer MUST terminate 
+            the corresponding Server-Sent Events connection with the Web Thing 
+            as specified in the Server-Sent Events specification
+            [[EVENTSOURCE]].
+          </p>
+          <p class="note" title="Terminating a connection using JavaScript">
+            A Server-Sent Events connection can be terminated in JavaScript 
+            [[ECMASCRIPT]] using the <code>close()</code> method on an 
+            <code>EventSource</code> [[EVENTSOURCE]] object.
+            <pre class="example">
+              overheatedEventSource.close();
+            </pre>
+          </p>
+        </section>
+
+        <section id="subscribeallevents">
+          <h5><code>subscribeallevents</code></h5>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-events-subscribeallevents-1">
+            The URL of a resource to be used when subscribing to all events 
+            emitted by a Web Thing MUST be obtained from a Canonical TD by
+            locating a
+            <a href="https://www.w3.org/TR/wot-thing-description/#form">
+            <code>Form</code></a> inside the top level 
+            <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json"><code>forms</code></a>
+            member of a Thing Description for which the value of its 
+            <code>op</code> member is <code>subscribeallevents</code> and the
+            <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+            scheme</a> [[RFC3986]] of the value of its <code>href</code> member
+            is <code>http</code> or <code>https</code>.
+            If multiple <code>Form</code>s meet these criteria but one 
+            <code>Form</code> has a <code>subprotocol</code> member with a value 
+            of <code>"sse"</code> then that <code>Form</code> SHOULD be used.
+          </p>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-events-subscribeallevents-2">
+            In order to subscribe to all events emitted by a Web Thing, a
+            Consumer MUST follow the Server-Sent Events [[EVENTSOURCE]]
+            specification to open a connection with the Web Thing at the URL of
+            the events resource.
           </p>
           <p>
-            <code>readpastevents</code> and <code>readallpastevents</code> do
-            not yet exist in the WoT Thing Description specification (see
-            <a href="https://github.com/w3c/wot-thing-description/issues/892">
-              #892
-            </a>).
+            This will usually involve the Consumer sending an HTTP request to
+            the Web Thing with:
+            <ul>
+              <li>Method set to <code>GET</code></li>
+              <li>URL set to the URL of the events resource</li>
+              <li>
+                <code>Accept</code> header set to <code>text/event-stream</code>
+              </li>
+              <li>
+                <code>Connection</code> header set to <code>keep-alive</code>
+              </li>
+            </ul>
+          </p>
+          <pre class="example">
+            GET /things/lamp/events HTTP/1.1
+            Host: mythingserver.com
+            Accept: text/event-stream
+            Connection: keep-alive
+          </pre>
+          <p class="note" title="Opening a connection using JavaScript">
+            A Server-Sent Events connection can be initiated in JavaScript 
+            [[ECMASCRIPT]] using an <code>EventSource</code> 
+            [[EVENTSOURCE]] object.
+            <pre class="example">
+              const lampEventsSource = new EventSource('/things/lamp/events');
+            </pre>
+          </p>
+          <p class="rfc2119-assertion" 
+          id="core-profile-protocol-binding-events-subscribeallevents-3">
+            If a Web Thing receives an HTTP request following the format
+            above then it MUST follow the Server-Sent Events 
+            [[EVENTSOURCE]] specification to maintain an open connection with 
+            the Consumer and push event data to the Consumer for all event 
+            types for which it has permission to subscribe.
+          </p>
+          <p>
+            This will usually involve the Web Thing initially sending an HTTP 
+            response to the Consumer with:
+            <ul>
+              <li>Status code set to <code>200</code></li>
+              <li>
+                <code>Content-Type</code> header set to 
+                <code>text/event-stream</code>
+              </li>
+            </ul>
+          </p>
+          <pre class="example">
+            HTTP/1.1 200 OK
+            Content-Type: text/event-stream
+          </pre>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-events-subscribeallevents-4">
+            Whenever an event occurs while the Web Thing has an open connection
+            with a Consumer, the Web Thing MUST send event data to the Consumer 
+            using the event stream format in the Server-Sent Events
+            [[EVENTSOURCE]] specification. For each message sent, the Web Thing
+            MUST set the <code>event</code> field to the 
+            name of the <code>EventAffordance</code> and populate the 
+            <code>data</code> field with event data, if any. The 
+            event data MUST follow the data schema specified in the
+            <code>EventAffordance</code> and MUST be serialized in JSON.
+          </p>
+          <pre class="example">
+            event: "overheated"
+            data: 90
+          </pre>
+          <p class="rfc2119-assertion" 
+          id="core-profile-protocol-binding-events-subscribeallevents-5">
+            If the connection between the Consumer and Web Thing drops
+            (except as a result of the <code>unsubscribeallevents</code>
+            operation defined below), the Consumer MUST re-establish the
+            connection following the steps outlined in the Server-Sent Events
+            specification [[EVENTSOURCE]]. Once the connection is re-established
+            the Web Thing SHOULD, if possible, send any missed events which
+            occured since the last event specified by the Consumer in a 
+            <code>Last-Event-ID</code> header.
+          </p>
+        </section>
+
+        <section id="unsubscribeallevents">
+          <h5><code>unsubscribeallevents</code></h5>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-events-unsubscribeallevents-1">
+            In order to unsubscribe from all events, a Consumer MUST terminate 
+            the corresponding Server-Sent Events connection with the events 
+            endpoint of the Web Thing, following the steps specified in the 
+            Server-Sent Events specification [[EVENTSOURCE]].
+          </p>
+          <p class="note" title="Terminating a connection using JavaScript">
+            A Server-Sent Events connection can be terminated in JavaScript 
+            [[ECMASCRIPT]] using the <code>close()</code> method on an 
+            <code>EventSource</code> [[EVENTSOURCE]] object.
+            <pre class="example">
+              lampEventsSource.close();
+            </pre>
           </p>
         </section>
       </section>
+
       <section id="error-responses">
         <h4>Error Responses</h4>
         <p>

--- a/index.html
+++ b/index.html
@@ -1906,7 +1906,7 @@
             resource.
           </p>
           <p>
-            This will usually involve the Consumer sending an HTTP request to
+            This involves the Consumer sending an HTTP request to
             the Web Thing with:
           </p>
           <ul>
@@ -1946,7 +1946,7 @@
             specified type are emitted.
           </p>
           <p>
-            This will usually involve the Web Thing initially sending an HTTP 
+            This involves the Web Thing initially sending an HTTP 
             response to the Consumer with:
           </p>
           <ul>
@@ -2056,7 +2056,7 @@
             the events resource.
           </p>
           <p>
-            This will usually involve the Consumer sending an HTTP request to
+            This involves the Consumer sending an HTTP request to
             the Web Thing with:
           </p>
           <ul>
@@ -2095,7 +2095,7 @@
             types for which it has permission to subscribe.
           </p>
           <p>
-            This will usually involve the Web Thing initially sending an HTTP 
+            This involves the Web Thing initially sending an HTTP 
             response to the Consumer with:
           </p>
           <ul>


### PR DESCRIPTION
This a proposed protocol binding for events in the Core Profile, using Server-Sent events.

As noted in #42, using WebSockets would require defining a sub-protocol and long-polling is a non-optimal solution. Server-Sent events are an attractive option because they are defined in an existing W3C specification which now enjoys broad native browser support. Server-Sent Events provide a simple mechanism to push events from a server to a client over HTTP, fit neatly with the WoT event data model and benefit from existing optimisations in user agents for maintaining persistent connections.

I hope that in the future the [Web Thing Protocol Community Group](https://www.w3.org/community/web-thing-protocol/) will specify a WoT sub-protocol for use with WebSockets, but that is unlikely to be standardised in time for the first version of the WoT Profile specification.

Notes:
- I noticed that the Protocol Binding Templates specification [uses](https://www.w3.org/TR/2020/NOTE-wot-binding-templates-20200130/#subscribe-notify-and-unsubscribe-event-http-binding-with-server-sent-event-subprotocol) a `POST` request for the initial SSE connection, but my understanding is that most existing SSE implementations use a `GET` request. I've therefore used a `GET` request in this protocol binding to maximise compatibility.
- The Core Profile Protocol Binding specification defers to the existing Server-Sent Events specification for details of how to initiate, maintain and terminate SSE connections. Any text describing SSE protocol details is therefore only informative and is marked as being non-normative.
- I haven't mentioned anything about CORS or supplying credentials in the text. Is it sufficient to defer to the SSE specification for these details?
- I specified that event stream messages sent as a result of a `subscribeevent` operation should include the name of the event that was emitted. Technically this is only necessary for `subscribeallevents` where messages may relate to multiple event types, but I have included it in both cases for consistency.
- [WebThings](https://webthings.io) does not currently support Sever-Sent Events (it uses WebSockets), but if this becomes part of the Core Profile then we are willing to implement SSE support.

Feedback welcome.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/92.html" title="Last updated on Sep 13, 2021, 4:53 PM UTC (34d8f6c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/92/f1ec8e2...benfrancis:34d8f6c.html" title="Last updated on Sep 13, 2021, 4:53 PM UTC (34d8f6c)">Diff</a>