### PR TITLE
Add timestamps to event protocol binding - closes #100

### DIFF
--- a/index.html
+++ b/index.html
@@ -3587,13 +3587,18 @@
 	  <span class="rfc2119-assertion" 
             id="http-sse-profile-protocol-binding-subscribeevent-6d">
             The <code>id</code> field SHOULD be set to a unique identifier for 
-            the event, for use when re-establishing a dropped connection.</span>  
-            See below.
+            the event, for use when re-establishing a dropped connection (see 
+            below).</span>
+    <span class="rfc2119-assertion" 
+            id="http-sse-profile-protocol-binding-subscribeevent-6e">
+            It is RECOMMENDED that the identifier is a timestamp 
+            representing the time at which the event ocurred, in the 
+            &quot;date-time&quot; format specified by [[RFC3339]].</span>
           </p>
           <pre class="example">
             event: overheated\n
             data: 90\n
-            id: 12345\n\n
+            id: 2021-11-16T16:53:50.817Z\n\n
           </pre>
 	  <p><span class="rfc2119-assertion" 
             id="http-sse-profile-protocol-binding-subscribeevent-7a">
@@ -3748,13 +3753,18 @@
 	  <span class="rfc2119-assertion" 
             id="http-sse-profile-protocol-binding-subscribeallevents-4d">
             The <code>id</code> field SHOULD be set to a unique identifier for 
-            the event, for use when re-establishing a dropped connection.</span>
-         See below.
+            the event, for use when re-establishing a dropped connection (see 
+            below).</span>
+    <span class="rfc2119-assertion" 
+            id="http-sse-profile-protocol-binding-subscribeallevents-4e">
+            It is RECOMMENDED that the identifier is a timestamp 
+            representing the time at which the event ocurred, in the 
+            &quot;date-time&quot; format specified by [[RFC3339]].</span>
       </p>
           <pre class="example">
             event: overheated\n
             data: 90\n
-            id: 12345\n\n
+            id: 2021-11-16T16:53:50.817Z\n\n
           </pre>
 	  <p><span class="rfc2119-assertion" 
             id="http-sse-profile-protocol-binding-subscribeallevents-5a">


### PR DESCRIPTION
This PR adds a recommendation that the `id` field of an event should be set to a timestamp in ISO 8601 format, as a way to include timestamps in events as requested by #100.

I was originally going to suggest a Number representing the number of milliseconds since the epoch [as defined in ECMAScript](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-time-values-and-time-range) (amongst may other programming languages), which is a common practice in Server-Sent Events. However, I'm concerned that may cause confusion given the current text in [5.1.1.2 Date format](https://w3c.github.io/wot-profile/#date-format) requires ISO 8601 format for "all date and time values".

I was initially concerned that using an ISO 8601 timestamp might make it harder for implementations to determine whether a given event occurred after the event identified by the `Last-Event-ID` header when dealing with a dropped connection, but upon closer reading of the specification I think it just tries to find an exact string match rather than calculating greater than or less than, so it shouldn't make any difference.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/119.html" title="Last updated on Nov 16, 2021, 4:57 PM UTC (90dd439)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/119/316ba88...benfrancis:90dd439.html" title="Last updated on Nov 16, 2021, 4:57 PM UTC (90dd439)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/119.html" title="Last updated on Jul 27, 2022, 4:16 PM UTC (be02dc0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/119/ecceb4d...benfrancis:be02dc0.html" title="Last updated on Jul 27, 2022, 4:16 PM UTC (be02dc0)">Diff</a>