### PR TITLE
Add Discovery section to HTTP Baseline Profile - closes #112

### DIFF
--- a/index.html
+++ b/index.html
@@ -2970,6 +2970,21 @@
         WoT Security Best Practices</a> for implementation advice.
       </p>
     </section>
+
+    <!-- Discovery -->
+    <section>
+      <h2 id="http-baseline-profile-discovery">Discovery</h2>
+      <p class="rfc2119-assertion" id="http-baseline-profile-discovery-1">
+        In order to conform with the HTTP Baseline Profile, a Web Thing's Thing 
+        Description [[wot-thing-description]] MUST be retrievable from a 
+        <a href="https://w3c.github.io/wot-architecture/#dfn-wot-thing-description-server">
+        Thing Description Server</a> [[wot-architecture11]] using an HTTP 
+        [[HTTP11]] URL provided by a 
+        <a href="https://w3c.github.io/wot-discovery/#introduction-mech">
+        Direct Introduction Mechanism</a> [[wot-discovery]].
+      </p>
+    </section>
+  </section>
   </section>
 
 


### PR DESCRIPTION
This PR adds a Discovery section to the Core Profile as suggested in #112.

I propose that the only mandatory discovery mechanism for the Core Profile should be Direct discovery, simply meaning that the Thing's Thing Description must be retrievable from an HTTP URL.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/121.html" title="Last updated on Nov 17, 2021, 4:20 PM UTC (5f83d3d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/121/316ba88...benfrancis:5f83d3d.html" title="Last updated on Nov 17, 2021, 4:20 PM UTC (5f83d3d)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/121.html" title="Last updated on Jul 27, 2022, 4:52 PM UTC (321d827)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/121/ecceb4d...benfrancis:321d827.html" title="Last updated on Jul 27, 2022, 4:52 PM UTC (321d827)">Diff</a>