### PR TITLE
Define protocol binding for observing properties - closes #95

### DIFF
--- a/index.html
+++ b/index.html
@@ -1583,6 +1583,159 @@
           HTTP/1.1 204 No Content
           </pre>
         </section>
+
+        <section id="observeproperty">
+          <h5><code>observeproperty</code></h5>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-properties-observeproperty-1">
+            The URL of a <code>Property</code> resource to be used when
+            observing the value of a property MUST be obtained from a Thing 
+            Description by locating a
+            <a href="https://www.w3.org/TR/wot-thing-description/#form">
+            <code>Form</code></a> inside the corresponding
+            <a href="https://www.w3.org/TR/wot-thing-description/#propertyaffordance">
+            <code>PropertyAffordance</code></a>
+            for which:
+          </p>
+          <ul class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-properties-observeproperty-2">
+            <li>
+              Its <code>op</code> member contains the value 
+              <code>observeproperty</code>
+            </li>
+            <li>
+              After being resolved against a base URL where applicable, the
+              <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+              scheme</a> [[RFC3986]] of the value of its <code>href</code>
+              member is <code>http</code> or <code>https</code>
+            </li>
+            <li>Its <code>subprotocol</code> member has a value of
+              <code>sse</code>
+            </li>
+          </ul>
+          <p class="rfc2119-assertion" 
+          id="core-profile-protocol-binding-properties-observeproperty-3">
+            The resolved value of the <code>href</code> member MUST then be used
+            as the URL of the <code>Property</code> resource.
+          </p>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-properties-observeproperty-4">
+            In order to observe a property, a Consumer MUST follow the 
+            Server-Sent Events [[EVENTSOURCE]] specification to open a
+            connection with the Web Thing at the URL of the 
+            <code>Property</code> resource.
+          </p>
+          <p>
+            This involves the Consumer sending an HTTP request to
+            the Web Thing with:
+          </p>
+          <ul>
+            <li>Method set to <code>GET</code></li>
+            <li>URL set to the URL of the <code>Property</code> resource</li>
+            <li>
+              <code>Accept</code> header set to <code>text/event-stream</code>
+            </li>
+            <li>
+              <code>Connection</code> header set to <code>keep-alive</code>
+            </li>
+          </ul>
+          <pre class="example">
+            GET /things/lamp/properties/level HTTP/1.1
+            Host: mythingserver.com
+            Accept: text/event-stream
+            Connection: keep-alive
+          </pre>
+          <p class="note" title="Opening a connection using JavaScript">
+            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed 
+            in a runtime which exposes the
+            <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface">
+            <code>EventSource</code></a> interface, a Server-Sent Events 
+            connection can be initiated using the <code>EventSource</code>
+            constructor.
+            <pre class="example">
+              const levelSource = new EventSource('/things/lamp/properties/level');
+            </pre>
+          </p>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-properties-observeproperty-5">
+            If a Web Thing receives an HTTP request following the format
+            above and the Consumer has permission to observe the 
+            corresponding property, then it MUST follow the Server-Sent Events 
+            [[EVENTSOURCE]] specification to maintain an open connection with 
+            the Consumer and push a property value to the Consumer each time 
+            the value of the specified property changes.
+          </p>
+          <p>
+            This involves the Web Thing initially sending an HTTP 
+            response to the Consumer with:
+          </p>
+          <ul>
+            <li>Status code set to <code>200</code></li>
+            <li>
+              <code>Content-Type</code> header set to 
+              <code>text/event-stream</code>
+            </li>
+          </ul>
+          <pre class="example">
+            HTTP/1.1 200 OK
+            Content-Type: text/event-stream
+          </pre>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-properties-observeproperty-6">
+            Whenever the value of the specified property changes while the Web 
+            Thing has an open connection with a Consumer, the Web Thing MUST 
+            send a property value to the Consumer using the event stream format in
+            the Server-Sent Events [[EVENTSOURCE]] specification. For each message 
+            sent, the Web Thing MUST set the <code>event</code> field to the 
+            name of the <code>PropertyAffordance</code> and populate the 
+            <code>data</code> field with the property value, serialized in JSON 
+            and following the data schema specified in the 
+            <code>PropertyAffordance</code>. The <code>id</code> field SHOULD be set to a unique 
+            identifier for the property change, for use when re-establishing a
+            dropped connection (see below). It is RECOMMENDED that the identifier
+            is a timestamp representing the time at which the property changed, in
+            the &quotdate-time&quot format specified by [[RFC3339]].
+          </p>
+          <pre class="example">
+            event: level\n
+            data: 42\n
+            id: 2021-11-17T15:33:20.827Z\n\n
+          </pre>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-properties-observeproperty-7">
+            If the connection between the Consumer and Web Thing drops
+            (except as a result of the <code>unobserve</code> operation 
+            defined below), the Consumer MUST re-establish the connection 
+            following the steps outlined in the Server-Sent Events specification
+            [[EVENTSOURCE]]. Once the connection is re-established the Web Thing
+            SHOULD, if possible, send any missed property changes which occured
+            since the last change specified by the Consumer in a 
+            <code>Last-Event-ID</code> header.
+          </p>
+        </section>
+
+        <section id="unobserveproperty">
+          <h5><code>unobserveproperty</code></h5>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-properties-unobserveproperty-1">
+            In order to stop observing a property, a Consumer MUST terminate 
+            the corresponding Server-Sent Events connection with the Web Thing 
+            as specified in the Server-Sent Events specification
+            [[EVENTSOURCE]].
+          </p>
+          <p class="note" title="Terminating a connection using JavaScript">
+            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed 
+            in a runtime which exposes the
+            <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface">
+            <code>EventSource</code></a> interface, a Server-Sent Events 
+            connection can be terminated using the <code>close()</code> method 
+            on an <code>EventSource</code> [[EVENTSOURCE]] object.
+            <pre class="example">
+              levelSource.close();
+            </pre>
+          </p>
+        </section>
+
         <section id="readallproperties">
           <h5><code>readallproperties</code></h5>
           <p class="rfc2119-assertion" 
@@ -1727,27 +1880,171 @@
           HTTP/1.1 204 No Content
           </pre>
         </section>
+
+        <section id="observeallproperties">
+          <h5><code>observeallproperties</code></h5>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-properties-observeallproperties-1">
+            The URL of a properties resource to be used when observing changes 
+            to all properties of a Web Thing MUST be obtained from a Thing
+            Description by locating a 
+            <a href="https://www.w3.org/TR/wot-thing-description/#form">
+            <code>Form</code></a> inside the top level 
+            <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json"><code>forms</code></a>
+            member of a Thing Description for which:
+          </p>
+          <ul class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-properties-observeallproperties">
+            <li>
+              Its <code>op</code> member contains the value 
+              <code>observeallproperties</code>
+            </li>
+            <li>
+              After being resolved against a base URL where applicable, the
+              <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+              scheme</a> [[RFC3986]] of the value of its <code>href</code>
+              member is <code>http</code> or <code>https</code>
+            </li>
+            <li>Its <code>subprotocol</code> member has a value of
+              <code>sse</code>
+            </li>
+          </ul>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-properties-observeallproperties-3">
+            The resolved value of the <code>href</code> member MUST then be used
+            as the URL of the properties resource.
+          </p>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-properties-observeallproperties-4">
+            In order to observe changes to all properties of a Web Thing, a
+            Consumer MUST follow the Server-Sent Events [[EVENTSOURCE]]
+            specification to open a connection with the Web Thing at the URL of
+            the properties resource.
+          </p>
+          <p>
+            This involves the Consumer sending an HTTP request to
+            the Web Thing with:
+          </p>
+          <ul>
+            <li>Method set to <code>GET</code></li>
+            <li>URL set to the URL of the properties resource</li>
+            <li>
+              <code>Accept</code> header set to <code>text/event-stream</code>
+            </li>
+            <li>
+              <code>Connection</code> header set to <code>keep-alive</code>
+            </li>
+          </ul>
+          <pre class="example">
+            GET /things/lamp/properties HTTP/1.1
+            Host: mythingserver.com
+            Accept: text/event-stream
+            Connection: keep-alive
+          </pre>
+          <p class="note" title="Opening a connection using JavaScript">
+            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed 
+            in a runtime which exposes the
+            <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface">
+            <code>EventSource</code></a> interface, a Server-Sent Events 
+            connection can be initiated using the <code>EventSource</code>
+            constructor.
+            <pre class="example">
+              const lampPropertiesSource = new EventSource('/things/lamp/properties');
+            </pre>
+          </p>
+          <p class="rfc2119-assertion" 
+          id="core-profile-protocol-binding-properties-observeallproperties-5">
+            If a Web Thing receives an HTTP request following the format
+            above then it MUST follow the Server-Sent Events 
+            [[EVENTSOURCE]] specification to maintain an open connection with 
+            the Consumer and push new property values to the Consumer for all 
+            properties for which it has permission to observe.
+          </p>
+          <p>
+            This involves the Web Thing initially sending an HTTP 
+            response to the Consumer with:
+          </p>
+          <ul>
+            <li>Status code set to <code>200</code></li>
+            <li>
+              <code>Content-Type</code> header set to 
+              <code>text/event-stream</code>
+            </li>
+          </ul>
+          <pre class="example">
+            HTTP/1.1 200 OK
+            Content-Type: text/event-stream
+          </pre>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-properties-observeallproperties-6">
+            Whenever a property changes while the Web Thing has an open 
+            connection with a Consumer, the Web Thing MUST send the new property
+            value to the Consumer using the event stream format in the 
+            Server-Sent Events [[EVENTSOURCE]] specification. For each message 
+            sent, the Web Thing MUST set the <code>event</code> field to the 
+            name of the <code>PropertyAffordance</code> and populate the 
+            <code>data</code> field with the new property value. The 
+            property data MUST follow the data schema specified in the
+            <code>PropertyAffordance</code> and MUST be serialized in JSON.
+            The <code>id</code> field SHOULD be set to a unique identifier for 
+            the event, for use when re-establishing a dropped connection (see 
+            below). It is RECOMMENDED that the identifier is a timestamp 
+            representing the time at which the property changed, in the 
+            &quotdate-time&quot format specified by [[RFC3339]].
+          </p>
+          <pre class="example">
+            event: level\n
+            data: 42\n
+            id: 2021-11-17T15:33:20.827Z\n\n
+          </pre>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-properties-observeallproperties-7">
+            If the connection between the Consumer and Web Thing drops
+            (except as a result of the <code>unobserveallproperties</code>
+            operation defined below), the Consumer MUST re-establish the
+            connection following the steps outlined in the Server-Sent Events
+            specification [[EVENTSOURCE]]. Once the connection is re-established
+            the Web Thing SHOULD, if possible, send any missed property changes 
+            which occured since the last change specified by the Consumer in a 
+            <code>Last-Event-ID</code> header.
+          </p>
+        </section>
+
+        <section id="unobserveallproperties">
+          <h5><code>unobserveallproperties</code></h5>
+          <p class="rfc2119-assertion" 
+            id="core-profile-protocol-binding-properties-unobserveallproperties-1">
+            In order to unobserve all properties, a Consumer MUST terminate 
+            the corresponding Server-Sent Events connection with the properties 
+            endpoint of the Web Thing, following the steps specified in the 
+            Server-Sent Events specification [[EVENTSOURCE]].
+          </p>
+          <p class="note" title="Terminating a connection using JavaScript">
+            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed 
+            in a runtime which exposes the
+            <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface">
+            <code>EventSource</code></a> interface, a Server-Sent Events 
+            connection can be terminated using the <code>close()</code> method 
+            on an <code>EventSource</code> [[EVENTSOURCE]] object.
+            <pre class="example">
+              lampPropertiesSource.close();
+            </pre>
+          </p>
+        </section>
+
         <section class="ednote">
           <p>
-            Other operations under consideration include
-            <code>observeproperty</code>, <code>unobserveproperty</code>,
-            <code>observeallproperties</code> and
-            <code>unobserveallproperties</code>.
-          </p>
-          <p>
-            These operations would require consesus on a default observe
-            mechanism for HTTP (e.g. Server Sent Events or WebSockets).
-          </p>
-          <p>
-            <code>readmultipleproperties</code> is currently excluded due to
-            the complexities of the request payload format and because it
-            doesn't add much functionality over <code>readproperty</code> and
-            <code>readallproperties</code>.
-            <code>writeallproperties</code> is currently excluded because it
-            is just a special case of <code>writemultipleproperties</code>.
+            The <code>readmultipleproperties</code> operation is currently 
+            excluded due to the complexities of the request payload format and
+            because it doesn't add much functionality over 
+            <code>readproperty</code> and <code>readallproperties</code>. The
+            <code>writeallproperties</code> operation is currently excluded 
+            because it is just a special case of 
+            <code>writemultipleproperties</code>.
           </p>
         </section>
       </section>
+
       <section id="actions">
         <h4>Actions</h4>
         <section id="invokeaction">
@@ -2291,7 +2588,7 @@
               member is <code>http</code> or <code>https</code>
             </li>
             <li>Its <code>subprotocol</code> member has a value of
-              <code>"sse"</code>
+              <code>sse</code>
             </li>
           </ul>
           <p class="rfc2119-assertion" 
@@ -2441,7 +2738,7 @@
               member is <code>http</code> or <code>https</code>
             </li>
             <li>Its <code>subprotocol</code> member has a value of
-              <code>"sse"</code>
+              <code>sse</code>
             </li>
           </ul>
           <p class="rfc2119-assertion" 
@@ -2450,7 +2747,7 @@
             as the URL of the events resource.
           </p>
           <p class="rfc2119-assertion" 
-            id="core-profile-protocol-binding-events-subscribeallevents-2">
+            id="core-profile-protocol-binding-events-subscribeallevents-4">
             In order to subscribe to all events emitted by a Web Thing, a
             Consumer MUST follow the Server-Sent Events [[EVENTSOURCE]]
             specification to open a connection with the Web Thing at the URL of
@@ -2488,7 +2785,7 @@
             </pre>
           </p>
           <p class="rfc2119-assertion" 
-          id="core-profile-protocol-binding-events-subscribeallevents-3">
+          id="core-profile-protocol-binding-events-subscribeallevents-5">
             If a Web Thing receives an HTTP request following the format
             above then it MUST follow the Server-Sent Events 
             [[EVENTSOURCE]] specification to maintain an open connection with 
@@ -2511,7 +2808,7 @@
             Content-Type: text/event-stream
           </pre>
           <p class="rfc2119-assertion" 
-            id="core-profile-protocol-binding-events-subscribeallevents-4">
+            id="core-profile-protocol-binding-events-subscribeallevents-6">
             Whenever an event occurs while the Web Thing has an open connection
             with a Consumer, the Web Thing MUST send event data to the Consumer 
             using the event stream format in the Server-Sent Events
@@ -2531,7 +2828,7 @@
             id: 12345\n\n
           </pre>
           <p class="rfc2119-assertion" 
-            id="core-profile-protocol-binding-events-subscribeallevents-5">
+            id="core-profile-protocol-binding-events-subscribeallevents-7">
             If the connection between the Consumer and Web Thing drops
             (except as a result of the <code>unsubscribeallevents</code>
             operation defined below), the Consumer MUST re-establish the


### PR DESCRIPTION
This is a proposed protocol binding for observing properties in the Core Profile, as discussed in #95. It includes bindings for the following WoT operations:
- `observeproperty`
- `unobserveproperty`
- `observeallproperties`
- `unobserveallproperties`

(There are also a few minor fixes to the HTML markup for the events protocol binding  which I noticed along the way).

This protocol binding uses the Server-Sent Events mechanism to push property changes to a Consumer, consistent with the events protocol binding.

Using the Server-Sent Events mechanism for observing properties isn't as obvious as using it for subscribing to events, but if a Consumer is already implementing SSE for events then it seems silly to use a completely different push mechanism for observing properties.

An alternative to Server-Sent Events would be long-polling, but this has many drawbacks:
- No built-in mechanism for re-establishing dropped connections
- No built-in mechanism for catching up on missed data
- No native API or network optimisations built into web browsers
- Higher load on the Producer/server due to repeated HTTP requests

Without this added feature currently the only way to observe property changes within the Core Profile is to manually poll a property URL with HTTP GET requests, which is very inefficient.

I would value feedback on this proposal.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/157.html" title="Last updated on Jan 10, 2022, 5:23 PM UTC (36b2338)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/157/707eee7...benfrancis:36b2338.html" title="Last updated on Jan 10, 2022, 5:23 PM UTC (36b2338)">Diff</a>