### PR TITLE
Example TDs for HTTP Baseline and HTTP SSE profiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1685,6 +1685,83 @@
         MUST implement this protocol binding.
         </span>
       </p>
+
+      <p>
+        The examples provided throughout this section describe how a Consumer
+        would communicate with a Web Thing which produces the following Thing
+        Description:
+      </p>
+
+      <pre class="example">
+        {
+          "@context": "https://www.w3.org/2019/wot/td/v1",
+          "id": "https://mywebthingserver.com/things/lamp",
+          "profile": "https://www.w3.org/2022/wot/profile/http-baseline/v1",
+          "base": "https://mywebthingserver.com/things/lamp/",
+          "title": "My Lamp",
+          "description": "A web connected lamp",
+          "securityDefinitions": {
+            "oauth2": {
+              "scheme": "oauth2",
+              "flow": "code",
+              "authorization": "https://mywebthingserver.com/oauth/authorize",
+              "token": "https://mywebthingserver.com/oauth/token"
+            }
+          },
+          "security": "oauth2",
+          "properties": {
+            "on": {
+              "type": "boolean",
+              "title": "On/Off",
+              "description": "Whether the lamp is turned on",
+              "forms": [{"href": "./properties/on"}]
+            },
+            "level" : {
+              "type": "integer",
+              "title": "Brightness",
+              "description": "The level of light from 0-100",
+              "unit": "percent",
+              "minimum" : 0,
+              "maximum" : 100,
+              "forms": [{"href": "./properties/level"}]
+            }
+          },
+          "actions": {
+            "fade": {
+              "title": "Fade",
+              "description": "Fade the lamp to a given level",
+              "input": {
+                "type": "object",
+                "properties": {
+                  "level": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "unit": "percent"
+                  },
+                  "duration": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "unit": "milliseconds"
+                  }
+                }
+              },
+              "forms": [{"href": "./actions/fade"}]
+            }
+          },
+          "forms": [
+            {
+              "op": ["readallproperties", "writemultipleproperties"],
+              "href": "./properties"
+            },
+            {
+              "op": "queryallactions",
+              "href": "./actions"
+            }
+          ]
+        }
+      </pre>
+
       <section id="http-baseline-profile-protocol-binding-properties">
         <h4>Properties</h4>
         <section id="http-baseline-profile-protocol-binding-readproperty">
@@ -2627,6 +2704,102 @@
         MUST implement this protocol binding.
         </span>
       </p>
+      <p>
+        The examples provided throughout this section describe how a Consumer
+        would communicate with a Web Thing which produces the following Thing
+        Description:
+      </p>
+      <pre class="example">
+        {
+          "@context": "https://www.w3.org/2019/wot/td/v1",
+          "id": "https://mywebthingserver.com/things/lamp",
+          "profile": [
+            "https://www.w3.org/2022/wot/profile/http-baseline/v1",
+            "https://www.w3.org/2022/wot/profile/http-sse/v1",
+          ],
+          "base": "https://mywebthingserver.com/things/lamp/",
+          "title": "My Lamp",
+          "description": "A web connected lamp",
+          "securityDefinitions": {
+            "oauth2": {
+              "scheme": "oauth2",
+              "flow": "code",
+              "authorization": "https://mywebthingserver.com/oauth/authorize",
+              "token": "https://mywebthingserver.com/oauth/token"
+            }
+          },
+          "security": "oauth2",
+          "properties": {
+            "on": {
+              "type": "boolean",
+              "title": "On/Off",
+              "description": "Whether the lamp is turned on",
+              "forms": [{"href": "./properties/on"}]
+            },
+            "level" : {
+              "type": "integer",
+              "title": "Brightness",
+              "description": "The level of light from 0-100",
+              "unit": "percent",
+              "minimum" : 0,
+              "maximum" : 100,
+              "forms": [{"href": "./properties/level"}]
+            }
+          },
+          "actions": {
+            "fade": {
+              "title": "Fade",
+              "description": "Fade the lamp to a given level",
+              "input": {
+                "type": "object",
+                "properties": {
+                  "level": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "unit": "percent"
+                  },
+                  "duration": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "unit": "milliseconds"
+                  }
+                }
+              },
+              "forms": [{"href": "./actions/fade"}]
+            }
+          },
+          "events": {
+            "overheated": {
+              "title": "Overheated",
+              "data": {
+                "type": "number",
+                "unit": "degree celsius"
+              },
+              "description": "The lamp has exceeded its safe operating temperature",
+              "forms": [{
+                "href": "./events/overheated",
+                "subprotocol": "sse"
+              }]
+            }
+          },
+          "forms": [
+            {
+              "op": ["readallproperties", "writemultipleproperties"],
+              "href": "./properties"
+            },
+            {
+              "op": "queryallactions",
+              "href": "./actions"
+            },
+            {
+              "op": ["subscribeallevents", "unsubscribeallevents"],
+              "href": "./events",
+              "subprotocol": "sse"
+            }
+          ]
+        }
+      </pre>
       <section id="http-sse-profile-protocol-binding-events">
         <h3>Events</h3>
         <p>

--- a/index.html
+++ b/index.html
@@ -1714,7 +1714,7 @@
               "type": "boolean",
               "title": "On/Off",
               "description": "Whether the lamp is turned on",
-              "forms": [{"href": "./properties/on"}]
+              "forms": [{"href": "properties/on"}]
             },
             "level" : {
               "type": "integer",
@@ -1723,7 +1723,7 @@
               "unit": "percent",
               "minimum" : 0,
               "maximum" : 100,
-              "forms": [{"href": "./properties/level"}]
+              "forms": [{"href": "properties/level"}]
             }
           },
           "actions": {
@@ -1746,17 +1746,17 @@
                   }
                 }
               },
-              "forms": [{"href": "./actions/fade"}]
+              "forms": [{"href": "actions/fade"}]
             }
           },
           "forms": [
             {
               "op": ["readallproperties", "writemultipleproperties"],
-              "href": "./properties"
+              "href": "properties"
             },
             {
               "op": "queryallactions",
-              "href": "./actions"
+              "href": "actions"
             }
           ]
         }
@@ -2734,7 +2734,7 @@
               "type": "boolean",
               "title": "On/Off",
               "description": "Whether the lamp is turned on",
-              "forms": [{"href": "./properties/on"}]
+              "forms": [{"href": "properties/on"}]
             },
             "level" : {
               "type": "integer",
@@ -2743,7 +2743,7 @@
               "unit": "percent",
               "minimum" : 0,
               "maximum" : 100,
-              "forms": [{"href": "./properties/level"}]
+              "forms": [{"href": "properties/level"}]
             }
           },
           "actions": {
@@ -2766,7 +2766,7 @@
                   }
                 }
               },
-              "forms": [{"href": "./actions/fade"}]
+              "forms": [{"href": "actions/fade"}]
             }
           },
           "events": {
@@ -2778,7 +2778,7 @@
               },
               "description": "The lamp has exceeded its safe operating temperature",
               "forms": [{
-                "href": "./events/overheated",
+                "href": "events/overheated",
                 "subprotocol": "sse"
               }]
             }
@@ -2786,15 +2786,15 @@
           "forms": [
             {
               "op": ["readallproperties", "writemultipleproperties"],
-              "href": "./properties"
+              "href": "properties"
             },
             {
               "op": "queryallactions",
-              "href": "./actions"
+              "href": "actions"
             },
             {
               "op": ["subscribeallevents", "unsubscribeallevents"],
-              "href": "./events",
+              "href": "events",
               "subprotocol": "sse"
             }
           ]


### PR DESCRIPTION
This PR replaces #91 and provides example Thing Descriptions used by the examples throughout the HTTP Baseline and HTTP SSE protocol binding sections.

Note that I have intentionally used a Thing Description which has both properties and events for the HTTP SSE Protocol Binding so that:
1. You can see how the HTTP SSE profile can build on top of the HTTP Baseline Profile
2. If and when #191 lands, I can modify the example to also include observing properties

I have not included the longer "declarative protocol binding illustration" example Thing Description from #91 because it no longer makes so much sense to have a single TD there, and decisions made for the Thing Description specification mean that parts of it are no longer valid anyway.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/195.html" title="Last updated on May 11, 2022, 8:36 AM UTC (131a0c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/195/d41bd09...benfrancis:131a0c8.html" title="Last updated on May 11, 2022, 8:36 AM UTC (131a0c8)">Diff</a>