### PR TITLE
Remove Note about vocabulary extensions - closes #17

### DIFF
--- a/index.html
+++ b/index.html
@@ -1345,17 +1345,6 @@
               If a Thing Description is provided externally, a support email
               address SHOULD be used.</span>
           </p>
-
-          <section class="note">
-            <p>
-              <span id="profile-thing-mandatory-fields-4">
-                It will be evaluated whether the profile also defines a new context  for 
-                some new TD terms that may be introduced in TD 2.0.</span>
-              Currently the following terms are discussed: serialNumber,
-              hardwareRevision, softwareRevision, loc_latitude, loc_longitude
-              loc_altitude, loc_height, and loc_depth.
-            </p>
-          </section>
         </section>
       </section>
 


### PR DESCRIPTION
I agree with @sebastiankb that WoT Profile 1.0 [should not extend the Thing Description vocabulary](https://github.com/w3c/wot-profile/issues/17#issuecomment-666207762).

I suggest we remove the note on this topic and agree not to extend the Thing Description information model, at least in this first version of WoT Profile.

Closes #17.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/247.html" title="Last updated on Jul 14, 2022, 1:15 PM UTC (7fed1cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/247/ecceb4d...benfrancis:7fed1cf.html" title="Last updated on Jul 14, 2022, 1:15 PM UTC (7fed1cf)">Diff</a>