### PR TITLE
Fix indentation and missing </section> tag - closes #214

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,16 +179,16 @@
     </section>
 
     <p>
-      <p id="profile-abstract-2">
-        The W3C WoT Thing Architecture [[wot-architecture11]] and
-        WoT Thing Description [[wot-thing-description11]] define a
-        powerful description mechanism and a format to describe
-        myriads of very different devices, which may be connected
-        over various protocols.
-        The format is very flexible and open
-        and puts very few normative requirements on devices that
-        implement it.</p>
-  
+    <p id="profile-abstract-2">
+      The W3C WoT Thing Architecture [[wot-architecture11]] and
+      WoT Thing Description [[wot-thing-description11]] define a
+      powerful description mechanism and a format to describe
+      myriads of very different devices, which may be connected
+      over various protocols.
+      The format is very flexible and open
+      and puts very few normative requirements on devices that
+      implement it.</p>
+
     <p>
       However, this flexibility de-facto prevents
       interoperability, since, without additional <strong>rules</strong>,
@@ -326,7 +326,7 @@
       <p>
         The aim of this specification is to formalize these
         agreements by defining a set of <strong>HTTP
-            Profiles</strong> based on the choices that were made by
+          Profiles</strong> based on the choices that were made by
         the implementers of Plugfest devices.
       </p>
       <p>
@@ -485,14 +485,14 @@
         <dfn> Baseline Information Model</dfn>
       </dt>
       <dd>
-         Synonym for <a>HTTP Baseline Information Model</a>
+        Synonym for <a>HTTP Baseline Information Model</a>
       </dd>
-      
+
       <dt>
         <dfn>Baseline Profile</dfn>
       </dt>
       <dd>
-          Synonym for <a>HTTP Baseline Profile</a>
+        Synonym for <a>HTTP Baseline Profile</a>
       </dd>
 
 
@@ -556,23 +556,23 @@
       <li>Simplifying thing description to have fewer variations.</li>
       <li>Limiting the effort for JSON implementation.</li>
     </ul>
-    <!-- 
+    <!--
     Note:
-    Siemens: There should be multiple forms permitted, concerns on size limits on TDs, there may be edge devices with huge TDs. 
-    We should not limit the length of a TD. Context extensions (e.g. for units) may need RDF processing, 
-    semantic annotations are needed for that purpose. For simple semantic annotations, a JSON parser is sufficient. 
-    It is not required for all uses cases of the profile to implement RDF processing. 
-    It is hard to find these numbers for limitations, in some cases you have to do a specific agreement with a 
-    customer to agree on their constaints / system limits, need to discuss with the customer, 
-    identify frameworks, background, we cannot find a consensus. 
+    Siemens: There should be multiple forms permitted, concerns on size limits on TDs, there may be edge devices with huge TDs.
+    We should not limit the length of a TD. Context extensions (e.g. for units) may need RDF processing,
+    semantic annotations are needed for that purpose. For simple semantic annotations, a JSON parser is sufficient.
+    It is not required for all uses cases of the profile to implement RDF processing.
+    It is hard to find these numbers for limitations, in some cases you have to do a specific agreement with a
+    customer to agree on their constaints / system limits, need to discuss with the customer,
+    identify frameworks, background, we cannot find a consensus.
     Each IoT project is different, each customer uses a different framework.
-    
+
     Ben: agree with all points of Sebastian, not all profiles should impose storage size and bandwidth limits.
-    
+
     Cristiano: Disagree with limit storage and bandwidth requirements and Use finite (maximum) resources.
-    
+
     Ege: agree on the requirement, we need to determine what we exactly mean with "complexity"
-    
+
     Oracle: Complexity applies to all potential adopters, i.e. things, gateways, edge, cloud
     -->
 
@@ -586,10 +586,10 @@
       Examples are the choice of properties vs. actions, use of PUT or POST for HTTP, observe protocols.
     </p>
     <!--
-    Notes: 
-    Intel: If something is really ambiguous, it needs to be updated in the TD, if there are multiple choices, 
-    Profile can narrow down to one choice. 
-    Ben: broadly support the requirement, however requiring that all profiles adopt the same ontology. 
+    Notes:
+    Intel: If something is really ambiguous, it needs to be updated in the TD, if there are multiple choices,
+    Profile can narrow down to one choice.
+    Ben: broadly support the requirement, however requiring that all profiles adopt the same ontology.
     Choice of actions vs. properties should be done in the TD.
     This will probably create new requirements for the TD spec.
     -->
@@ -609,10 +609,10 @@
     <!--
       Some people are concerned about fragmentation, if multiple profiles would be defined.
       However this requirement is about the mechanism to identify the profile in use.
-  
-    Discussion: 
-    Does this mean a thing can support multiple profiles? 
-    TD already supports multiple profiles Profiling mechanism is described in the profile spec, 
+
+    Discussion:
+    Does this mean a thing can support multiple profiles?
+    TD already supports multiple profiles Profiling mechanism is described in the profile spec,
     may need to be polished
     -->
 
@@ -660,35 +660,35 @@
     CoAP. Websockets are another example, these should be allowed in the same TD
     -->
     <!--
-      
+
     <h3>Limit resource consumption</h3>
     Supporters: Oracle, Siemens (-), Fujitsu, Ben (-), Cristiano (-)
-    
+
     Profiles should limit the maximum amount of resources necessary to generate and consume a TD.
-    
-    Notes: 
-    
-    Sebastian: We do not want limits in a profile for non-resource constrained devices. 
-    I don't see the need for the current profile. 
-    
-    Ben: Agree that it is fine to have a profile for resource constrained devices, but should not be here. 
-    
-    Cristiano: Goal overlaps with limit and reduce complexity, this is use case specific, for a set of constrained devices 
-    
+
+    Notes:
+
+    Sebastian: We do not want limits in a profile for non-resource constrained devices.
+    I don't see the need for the current profile.
+
+    Ben: Agree that it is fine to have a profile for resource constrained devices, but should not be here.
+
+    Cristiano: Goal overlaps with limit and reduce complexity, this is use case specific, for a set of constrained devices
+
     Oracle: All devices have resource limits. Reasonable limits increase interop, because they can be supported by a wide population of things. This will increase the likeliness of profile adoption/WoT adoption.
-    
+
     <h3>Follow Security and Privacy Best Practices</h3>
     Proposers: Intel, Ben(*)
-    
+
     Profiles should not specify security and protocol combinations that do not satisfy security best practices as described in the WoT Security Best Practices document.
-    
+
     New security schemes may be added, others may be deprecated. McCool: Security best practices / guidelines are not published yet, no single scheme can be recommended, we cannot implement it across the use cases. Profile should follow best practices, we should discourage usage of insecure protocol. This could be a note to an informative document. Ben: subject to review of the actual best practices
-    
+
     <h3>Developer Mode</h3>
     Proposers: Intel, Ben(-)
-    
+
     There should be a mechanism to allow the "nosec" security scheme but only in a Developer context. Nosec may still be useful in a closed network even for production.
-    
+
     Notes: this overlaps with previous section Cristiano: We can make this just a recommendation.
     -->
   </section>
@@ -743,183 +743,187 @@
       The HTTP Profile specification defines several profiles that can be used for dedicated use cases.
 
     </p>
-  <!--  Common -->
-  <section id="sec-http-common-rules">
-    <h3>Common Rules</h3>
-    <p>
-      The following sections are applicable for all profiles defined by this document.
-    </p>
+    <!--  Common -->
+    <section id="sec-http-common-rules">
+      <h3>Common Rules</h3>
+      <p>
+        The following sections are applicable for all profiles defined by this document.
+      </p>
 
 
 
-    <section id="sec-default-language">
-      <h4>Default Language</h4>
-      <p><span class="rfc2119-assertion" id="common-rules-default-language">
-        One Map contained in an <code>@context Array</code> MUST contain a name-value pair 
-        that defines the default language for the Thing Description, 
-        where the name is the Term <code>@language</code> and the value 
-        is a well-formed language tag as defined by [BCP47] 
-        (e.g., en, de-AT, gsw-CH, zh-Hans, zh-Hant-HK, sl-nedis).</span>
-      </span>
-    </section>
+      <section id="sec-default-language">
+        <h4>Default Language</h4>
+        <p><span class="rfc2119-assertion" id="common-rules-default-language">
+            One Map contained in an <code>@context Array</code> MUST contain a name-value pair
+            that defines the default language for the Thing Description,
+            where the name is the Term <code>@language</code> and the value
+            is a well-formed language tag as defined by [BCP47]
+            (e.g., en, de-AT, gsw-CH, zh-Hans, zh-Hant-HK, sl-nedis).</span>
+          </span>
+      </section>
 
-          <!-- Links -->
-          <section id="links">
-            <h3>Links</h3>
-    
-              <p>Hypermedia links in the HTTP Profiles are significantly contrained to ensure a common interpretation 
-                and interoperability between things and consumers.</p>
-    
-            <p>
-              <span class="rfc2119-assertion" id="profile-thing-links-1">The following keywords are defined for the 
-                HTTP profiles and MUST be supported by all consumers.</span>
-            </p>
-            <p>
-              <span class="rfc2119-assertion" id="profile-thing-links-2">Other keywords for links MAY 
-                be present in a TD, however their interpretation is undefined
-                in the context of the HTTP profile</span>
-                <span class="rfc2119-assertion" id="profile-thing-links-3">These keywords MAY 
-                  be ignored by all profile-compliant consumers.</span>
-            </p>
-            <!-- TD 5.3.4.1 -->
-            <table class="def">
-              <thead>
-                <tr>
-                  <th>Keyword</th>
-                  <th>Type</th>
-                  <th>Constraint</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td><code>href</code></td>
-                  <td>IRI of the link target</td>
-                  <td>mandatory,<code>anyURI</code></td>
-                </tr>
-                <tr>
-                  <td><code>type</code></td>
-                  <td>media type [RFC2046] of the link target</td>
-                  <td>mandatory, the supported set of media types is defined in 
-                    <a href="#sec-link-relation-types">Media Types for Link Targets</a> below.</td>
-                </tr>
-                <tr>
-                  <td><code>rel</code></td>
-                  <td>link relation type <a href="https://www.iana.org/assignments/link-relations/link-relations.xhtml">IANA Link Relations</a></td>
-                  <td>mandatory, the supported subset of relation types is described in
-                    <a href="#sec-link-relation-types">Link Relation Types</a> below.</td>
-                </tr>
-                <tr>
-                  <td><code>sizes</code></td>
-                  <td>string with icon dimensions</td>
-                  <td>mandatory for <code>icon</code> link targets, forbidden otherwise.</td>
-                </tr>
-                <tr>
-                  <td><code>hreflang</code></td>
-                  <td><code>array of string</code> with valid language tags according to [BCP47]</td>
-                  <td>mandatory.</td>
-                </tr>
-              </tbody>
-            </table>
-    
-            <section id="sec-link-relation-types">
-              <h3>Link Relation Types</h3>
-            <table class="def">
-              <thead>
-                <tr>
-                  <th>Relation Type</th>
-                  <th>Constraint</th>
-                  <th>Remarks</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td><code>icon</code></td>
-                  <td>supported media types: <code>image/png</code>, <code>image/jpeg</code>. </td>
-                  <td><strong>TODO:</strong> sizes tbd., quadratig icons only?.</td>
-                </tr>
-                <tr>
-                  <td><code>type</code></td>
-                  <td>link target MUST be a profile-compliant <a>Thing Model</a></td>
-                  <td>No other types are defined in the Profile.</td>
-                </tr>
-                <tr>
-                  <td><code>service-doc</code></td>
-                  <td>human readable documentation, supported formats are Unicode Text, markdown, HTML and PDF.</td>
-                  <td></td>
-                </tr>
-                <tr>
-                  <td><code>collection</code></td>
-                  <td>link target is a collection of things or thing models.</td>
-                  <td></td>
-                </tr>
-                <tr>
-                  <td><code>item</code></td>
-                  <td>link target is a collection member of the thing or thing model.</td>
-                  <td></td>
-                </tr>
-    
-              </tbody>
-            </table>
-            </section>
-    
-            <section id="sec-link-media-types">
-              <h3>Media Types for Link Targets</h3>
-    
-              <span class="rfc2119-assertion" id="profile-thing-links-media-types-1">The following media types from <a href="https://www.iana.org/assignments/media-types/media-types.xhtml">IANA</a>
-                are defined for the link targets of compliant TDs. They MUST be supported by all consumers.</span>
-              <span class="rfc2119-assertion" id="profile-thing-links-2">Other media types MAY be present in a TD. </span>
-              <span class="rfc2119-assertion" id="profile-thing-links-3">Their interpretation is undefined
-              in the context of the HTTP profile and they MAY be ignored by all profile-compliant consumers.</span>
-            <table class="def">
-              <thead>
-                <tr>
-                  <th>Type</th>
-                  <th>Constraint</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td><code>text/plain</code></td>
-                  <td>charset=UTF-8</td>
-                </tr>
-                <tr>
-                  <td><code>text/html</code></td>
-                  <td></td>
-                </tr>
-                <tr>
-                  <tr>
-                    <td><code>text/markdown</code></td>
-                    <td>charset=UTF-8</td>
-                  </tr> 
-                  <tr>
-                    <td><code>text/pdf</code></td>
-                    <td></td>
-                  </tr> 
-                <td><code>application/json</code></td>
-                  <td></td>
-                </tr>
-                <tr>
-                  <td><code>application/ld+json</code></td>
-                  <td></td>
-                </tr>
-                <tr>
-                  <td><code> application/octet-stream</code></td>
-                  <td></td>
-                </tr>
-                <tr>
-                  <td><code>image/jpeg</code></td>
-                  <td></td>
-                </tr>
-                <tr>
-                  <td><code>image/png</code></td>
-                  <td></td>
-                </tr>
-    
-              </tbody>
-            </table>
-            </section>
-    
-               <!-- TODO 
+      <!-- Links -->
+      <section id="links">
+        <h3>Links</h3>
+
+        <p>Hypermedia links in the HTTP Profiles are significantly contrained to ensure a common interpretation
+          and interoperability between things and consumers.</p>
+
+        <p>
+          <span class="rfc2119-assertion" id="profile-thing-links-1">The following keywords are defined for the
+            HTTP profiles and MUST be supported by all consumers.</span>
+        </p>
+        <p>
+          <span class="rfc2119-assertion" id="profile-thing-links-2">Other keywords for links MAY
+            be present in a TD, however their interpretation is undefined
+            in the context of the HTTP profile</span>
+          <span class="rfc2119-assertion" id="profile-thing-links-3">These keywords MAY
+            be ignored by all profile-compliant consumers.</span>
+        </p>
+        <!-- TD 5.3.4.1 -->
+        <table class="def">
+          <thead>
+            <tr>
+              <th>Keyword</th>
+              <th>Type</th>
+              <th>Constraint</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>href</code></td>
+              <td>IRI of the link target</td>
+              <td>mandatory,<code>anyURI</code></td>
+            </tr>
+            <tr>
+              <td><code>type</code></td>
+              <td>media type [RFC2046] of the link target</td>
+              <td>mandatory, the supported set of media types is defined in
+                <a href="#sec-link-relation-types">Media Types for Link Targets</a> below.
+              </td>
+            </tr>
+            <tr>
+              <td><code>rel</code></td>
+              <td>link relation type <a href="https://www.iana.org/assignments/link-relations/link-relations.xhtml">IANA
+                  Link Relations</a></td>
+              <td>mandatory, the supported subset of relation types is described in
+                <a href="#sec-link-relation-types">Link Relation Types</a> below.
+              </td>
+            </tr>
+            <tr>
+              <td><code>sizes</code></td>
+              <td>string with icon dimensions</td>
+              <td>mandatory for <code>icon</code> link targets, forbidden otherwise.</td>
+            </tr>
+            <tr>
+              <td><code>hreflang</code></td>
+              <td><code>array of string</code> with valid language tags according to [BCP47]</td>
+              <td>mandatory.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <section id="sec-link-relation-types">
+          <h3>Link Relation Types</h3>
+          <table class="def">
+            <thead>
+              <tr>
+                <th>Relation Type</th>
+                <th>Constraint</th>
+                <th>Remarks</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>icon</code></td>
+                <td>supported media types: <code>image/png</code>, <code>image/jpeg</code>. </td>
+                <td><strong>TODO:</strong> sizes tbd., quadratig icons only?.</td>
+              </tr>
+              <tr>
+                <td><code>type</code></td>
+                <td>link target MUST be a profile-compliant <a>Thing Model</a></td>
+                <td>No other types are defined in the Profile.</td>
+              </tr>
+              <tr>
+                <td><code>service-doc</code></td>
+                <td>human readable documentation, supported formats are Unicode Text, markdown, HTML and PDF.</td>
+                <td></td>
+              </tr>
+              <tr>
+                <td><code>collection</code></td>
+                <td>link target is a collection of things or thing models.</td>
+                <td></td>
+              </tr>
+              <tr>
+                <td><code>item</code></td>
+                <td>link target is a collection member of the thing or thing model.</td>
+                <td></td>
+              </tr>
+
+            </tbody>
+          </table>
+        </section>
+
+        <section id="sec-link-media-types">
+          <h3>Media Types for Link Targets</h3>
+
+          <span class="rfc2119-assertion" id="profile-thing-links-media-types-1">The following media types from <a
+              href="https://www.iana.org/assignments/media-types/media-types.xhtml">IANA</a>
+            are defined for the link targets of compliant TDs. They MUST be supported by all consumers.</span>
+          <span class="rfc2119-assertion" id="profile-thing-links-2">Other media types MAY be present in a TD. </span>
+          <span class="rfc2119-assertion" id="profile-thing-links-3">Their interpretation is undefined
+            in the context of the HTTP profile and they MAY be ignored by all profile-compliant consumers.</span>
+          <table class="def">
+            <thead>
+              <tr>
+                <th>Type</th>
+                <th>Constraint</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>text/plain</code></td>
+                <td>charset=UTF-8</td>
+              </tr>
+              <tr>
+                <td><code>text/html</code></td>
+                <td></td>
+              </tr>
+              <tr>
+              <tr>
+                <td><code>text/markdown</code></td>
+                <td>charset=UTF-8</td>
+              </tr>
+              <tr>
+                <td><code>text/pdf</code></td>
+                <td></td>
+              </tr>
+              <td><code>application/json</code></td>
+              <td></td>
+              </tr>
+              <tr>
+                <td><code>application/ld+json</code></td>
+                <td></td>
+              </tr>
+              <tr>
+                <td><code> application/octet-stream</code></td>
+                <td></td>
+              </tr>
+              <tr>
+                <td><code>image/jpeg</code></td>
+                <td></td>
+              </tr>
+              <tr>
+                <td><code>image/png</code></td>
+                <td></td>
+              </tr>
+
+            </tbody>
+          </table>
+        </section>
+
+        <!-- TODO
               <h3 id="links-ednote">TODO</h3>THIS SECTION STILL NEEDS TO BE REWORKED.</section>
               <p>
               <span class="rfc2119-assertion" id="profile-thing-security-1">
@@ -946,7 +950,7 @@
                   support <strong>all</strong> of the following security schemes:
                 </span>
             </p>
-    
+
             <ul>
               <li>no security</li>
               <li>Basic Auth</li>
@@ -954,32 +958,33 @@
               <li>Bearer Token</li>
               <li>Oauth2</li>
             </ul>
-    
+
             <section>
               <h4>Recommended Practice</h4>
               <p>When using the "no security" or "Basic Auth"
                 security schemes it is strongly recommended to
                 use transport layer encryption.</p>
             </section-->
-          </section>
-        </section>
+      </section>
+    </section>
 
     <section id="sec-security-considerations">
-    <h4>Security Considerations</h4>
-    <p><span class="rfc2119-assertion" id="arch-security-consideration-separate-security-data">
-      The security considerations of the 
-      <a href="https://w3c.github.io/wot-architecture/#sec-security-consideration">WoT Architecture</a>
-      and 
-      <a href="https://w3c.github.io/wot-thing-description/#sec-security-considerations">WoT Thing Description</a>
-      MUST be adopted by compliant implementations.</span>
-    </p>
-  </section>
+      <h4>Security Considerations</h4>
+      <p><span class="rfc2119-assertion" id="arch-security-consideration-separate-security-data">
+          The security considerations of the
+          <a href="https://w3c.github.io/wot-architecture/#sec-security-consideration">WoT Architecture</a>
+          and
+          <a href="https://w3c.github.io/wot-thing-description/#sec-security-considerations">WoT Thing Description</a>
+          MUST be adopted by compliant implementations.</span>
+      </p>
+    </section>
     <!--  Security -->
     <section id="sec-http-security-schemes">
       <h4>Security Schemes</h3>
         <div class="rfc2119-assertion" id="http-baseline-profile-security-1">
           <p>
-            Below is a list of <a href="https://w3c.github.io/wot-thing-description/#sec-security-vocabulary-definition">
+            Below is a list of <a
+              href="https://w3c.github.io/wot-thing-description/#sec-security-vocabulary-definition">
               security schemes</a> [[wot-thing-description]] which conformant Web
             Things MAY use:
           </p>
@@ -1033,16 +1038,16 @@
             <a href="https://w3c.github.io/wot-thing-description/#form"></a><code>
               Form</code>s.</span>
         </p>
-    </section>   
+    </section>
     <section id="sec-privacy-considerations">
       <h4>Privacy Considerations</h4>
       <p><span class="rfc2119-assertion" id="profile-privacy-consideration">
-        The privacy considerations of the 
-        <a href="https://w3c.github.io/wot-architecture/#sec-privacy-considerations">WoT Architecture</a>
-        and 
-        <a href="https://w3c.github.io/wot-thing-description/#sec-privacy-consideration">WoT Thing Description</a>
-        MUST be adopted by compliant implementations.</span>
-      </p> 
+          The privacy considerations of the
+          <a href="https://w3c.github.io/wot-architecture/#sec-privacy-considerations">WoT Architecture</a>
+          and
+          <a href="https://w3c.github.io/wot-thing-description/#sec-privacy-consideration">WoT Thing Description</a>
+          MUST be adopted by compliant implementations.</span>
+      </p>
     </section>
   </section>
 
@@ -1065,12 +1070,12 @@
     <section id="http-baseline-profile-identifier">
       <h2>Identifier</h2>
       <p><span class="rfc2119-assertion" id="http-baseline-profile-identifier-1">
-        In order to denote that a given
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
-        conforms to the HTTP Baseline Profile, its Thing Description MUST have a
-        <a href="https://w3c.github.io/wot-thing-description/#thing">
-          <code>profile</code></a> member [[wot-thing-description]] with a value
-        of <code>https://www.w3.org/2022/wot/profile/http-baseline/v1</code>.</span>
+          In order to denote that a given
+          <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+          conforms to the HTTP Baseline Profile, its Thing Description MUST have a
+          <a href="https://w3c.github.io/wot-thing-description/#thing">
+            <code>profile</code></a> member [[wot-thing-description]] with a value
+          of <code>https://www.w3.org/2022/wot/profile/http-baseline/v1</code>.</span>
       </p>
     </section>
 
@@ -1084,12 +1089,12 @@
         and are normative.
       </p>
       <p><span class="rfc2119-assertion" id="profile-http-baseline-information-model-1">
-        A baseline profile compliant implementation MUST be compliant to the Thing Description and 
-        MUST additionally satisfy the requirements of this chapter.</span>
+          A baseline profile compliant implementation MUST be compliant to the Thing Description and
+          MUST additionally satisfy the requirements of this chapter.</span>
       </p>
 
       <section class="ednote" At RISK>
-        This section is at risk and needs to be further discussed in 
+        This section is at risk and needs to be further discussed in
         https://github.com/w3c/wot-profile/issues/10.
       </section>
 
@@ -1100,16 +1105,17 @@
           from the data of the Thing Description without further out of band information.
           For this purpose a minimum set of information is required to be present in all <a>Thing Descriptions</a>.
           A common way to display IoT device data are dashboards that are constructed from various UI widgets.
-          Typical elements are gauges, graphs, labels, histograms and labeled text fileds that display a value of properties.
-          Actions are typically triggered by labeled buttons.            
+          Typical elements are gauges, graphs, labels, histograms and labeled text fileds that display a value of
+          properties.
+          Actions are typically triggered by labeled buttons.
         </p>
         <p>
-        It is common for UIs to have an information button or a hovering text box on fields, 
-        that shows the human user an additional description, when needed.
-      </p>
+          It is common for UIs to have an information button or a hovering text box on fields,
+          that shows the human user an additional description, when needed.
+        </p>
         <p>
-          The profile contains a few length limitations on fields to ensure that automaticall generated UIs 
-          are possible. 
+          The profile contains a few length limitations on fields to ensure that automaticall generated UIs
+          are possible.
           For numeric values the range (minimum, maximum) should be provided to enable the display of graphs and gauges.
           Values with have a metric unit should contain a unit field to ensure a common interpretation by consumers.
         </p>
@@ -1124,69 +1130,69 @@
           <h4>Common fields</h4>
           <!-- TODO: -->
           <p><span class="rfc2119-assertion" id="profile-title-mandatory">
-            The field
-            <code>title</code>  
-            MUST be included for Things, Property Affordances,
-            Action Affordances, Event Affordances and Data
-            Schemas.</span>
+              The field
+              <code>title</code>
+              MUST be included for Things, Property Affordances,
+              Action Affordances, Event Affordances and Data
+              Schemas.</span>
           </p>
         </section>
 
         <section>
           <h4>Recommended fields</h4>
           <p><span class="rfc2119-assertion" id="profile-description-recommended">
-          The field
-          <code>description</code> is 
-          RECOMMENDED for Things, Property Affordances,
-          Action Affordances, Event Affordances and Data
-          Schemas.</span>
+              The field
+              <code>description</code> is
+              RECOMMENDED for Things, Property Affordances,
+              Action Affordances, Event Affordances and Data
+              Schemas.</span>
           </p>
-        <p>
-          This recommendation enables generic UIs and provides additional 
-          documentation for development and maintenance activities.
-        </p>
-      </section>
-
-      <section>
-        <h4>Type and Value Constraints</h4>
-          <h4>Date format</h4>
-	        <p>
-            <span class="rfc2119-assertion" id="profile-date-format-1">
-            All date and time values MUST use the canonical dateTime representation format defined in section 3.2.7 of [xmlschema-2].</span>
-	        As described by this section the following constraints must be observed:
-	        <span class="rfc2119-assertion" id="profile-date-format-2">
-            All dateTime values MUST use UTC as the time zone and use the 'Z' identifier.</span>
-	        <span class="rfc2119-assertion" id="profile-date-format-3">
-	          A time value of 24:00 is not permitted; the value 00:00 MUST be used instead.</span>
-        </p>		
-
-        <section>
-          <h4>Length and Value Limits</h4>
-          <p><span class="rfc2119-assertion" id="profile-title-max-length">
-            The length of
-            <code>title</code>
-            and
-            <code>titles</code>
-            values is limited to 64 characters.</span>
-          <span class="rfc2119-assertion" id="profile-description-max-length">
-            The length of
-            <code>id</code>, <code>description</code> and
-            <code>descriptions</code>
-            values MUST NOT exceed to 512 characters.</span>
+          <p>
+            This recommendation enables generic UIs and provides additional
+            documentation for development and maintenance activities.
           </p>
         </section>
 
+        <section>
+          <h4>Type and Value Constraints</h4>
+          <h4>Date format</h4>
+          <p>
+            <span class="rfc2119-assertion" id="profile-date-format-1">
+              All date and time values MUST use the canonical dateTime representation format defined in section 3.2.7 of
+              [xmlschema-2].</span>
+            As described by this section the following constraints must be observed:
+            <span class="rfc2119-assertion" id="profile-date-format-2">
+              All dateTime values MUST use UTC as the time zone and use the 'Z' identifier.</span>
+            <span class="rfc2119-assertion" id="profile-date-format-3">
+              A time value of 24:00 is not permitted; the value 00:00 MUST be used instead.</span>
+          </p>
+
+          <section>
+            <h4>Length and Value Limits</h4>
+            <p><span class="rfc2119-assertion" id="profile-title-max-length">
+                The length of
+                <code>title</code>
+                and
+                <code>titles</code>
+                values is limited to 64 characters.</span>
+              <span class="rfc2119-assertion" id="profile-description-max-length">
+                The length of
+                <code>id</code>, <code>description</code> and
+                <code>descriptions</code>
+                values MUST NOT exceed to 512 characters.</span>
+            </p>
+          </section>
+
           <p><span class="rfc2119-assertion"
-            id="profile-wot-http-baseline-profile-data-model-length-and-value-Limits-1">
-            Where a type permits using an
-            <code>array of string</code>
-            or a
-            <code>string</code>
-            , an
-            <code>array of string</code>
-            MUST be used.</span>
-          <span class="rfc2119-assertion"
-              id="profile-wot-http-baseline-profile-data-model-length-and-value-Limits-2">
+              id="profile-wot-http-baseline-profile-data-model-length-and-value-Limits-1">
+              Where a type permits using an
+              <code>array of string</code>
+              or a
+              <code>string</code>
+              , an
+              <code>array of string</code>
+              MUST be used.</span>
+            <span class="rfc2119-assertion" id="profile-wot-http-baseline-profile-data-model-length-and-value-Limits-2">
               The only exception to this rule are <code>@context</code> and <code>@type</code> annotations,
               where both <code>string</code> or <code>array of string</code> MAY be used.</span>
           </p>
@@ -1195,8 +1201,7 @@
         </p>
 
         <p>
-          <span class="rfc2119-assertion"
-            id="profile-wot-http-baseline-profile-data-model-length-and-value-Limits-3">
+          <span class="rfc2119-assertion" id="profile-wot-http-baseline-profile-data-model-length-and-value-Limits-3">
             Where a type permits using an
             <code>array of DataSchema</code>
             or a
@@ -1206,16 +1211,14 @@
             MUST be used.</span>
         </p>
         <p>
-          <span class="rfc2119-assertion"
-            id="profile-wot-http-baseline-profile-data-model-length-and-value-Limits-4">
+          <span class="rfc2119-assertion" id="profile-wot-http-baseline-profile-data-model-length-and-value-Limits-4">
             All elements of an
             <code>enum</code>
             MUST be either
             <code>string</code>
             or
             <code>number</code>.</span>
-          <span class="rfc2119-assertion"
-            id="profile-wot-http-baseline-profile-data-model-length-and-value-Limits-5">
+          <span class="rfc2119-assertion" id="profile-wot-http-baseline-profile-data-model-length-and-value-Limits-5">
             Different types in a single
             <code>enum</code>
             MUST NOT be used.</span>
@@ -1231,60 +1234,60 @@
         <section>
           <h3>Mandatory fields</h3>
           <div class="rfc2119-assertion" id="profile-thing-mandatory-fields-1">
-          <p>
+            <p>
               To provide minimum interoperability, the
               following metadata fields of a <a>Thing</a> MUST
               be contained in a compliant Thing Description:
-          </p>
-          <table class="def">
-            <thead>
-              <tr>
-                <th>Keyword</th>
-                <th>Type</th>
-                <th>Constraints</th>
-                <th>Rationale</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>title</td>
-                <td><code>string</code></td>
-                <td></td>
-                <td>generic UI</td>
-              </tr>
-              <tr>
-                <td>base</td>
-                <td><code>anyURI</code></td>
-                <td></td>
+            </p>
+            <table class="def">
+              <thead>
+                <tr>
+                  <th>Keyword</th>
+                  <th>Type</th>
+                  <th>Constraints</th>
+                  <th>Rationale</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>title</td>
+                  <td><code>string</code></td>
+                  <td></td>
+                  <td>generic UI</td>
+                </tr>
+                <tr>
+                  <td>base</td>
+                  <td><code>anyURI</code></td>
+                  <td></td>
                   <td>discovery</td>
-              </tr>
-              <tr>
-                <td>id</td>
-                <td><code>urn_type</code></td>
-                <td>a Globally unique urn of the
-                  thing</td>
+                </tr>
+                <tr>
+                  <td>id</td>
+                  <td><code>urn_type</code></td>
+                  <td>a Globally unique urn of the
+                    thing</td>
                   <td>large scale deployments</td>
-              </tr>
-              <tr>
-                <td>profile</td>
-                <td><code>string</code></td>
-                <td>value: "https://www.w3.org/2022/wot/profile/http-baseline/v1"</td>
-              </tr>
-              <tr>
-                <td>version</td>
-                <td><code>VersionInfo</code></td>
-                <td>semantic versioning as defined by [SEMVER]</td>
-                <td>enforce versioning, easy to
-                  distinguish different versions of the same TD</td>
-              </tr>
-            </tbody>
-          </table>
+                </tr>
+                <tr>
+                  <td>profile</td>
+                  <td><code>string</code></td>
+                  <td>value: "https://www.w3.org/2022/wot/profile/http-baseline/v1"</td>
+                </tr>
+                <tr>
+                  <td>version</td>
+                  <td><code>VersionInfo</code></td>
+                  <td>semantic versioning as defined by [SEMVER]</td>
+                  <td>enforce versioning, easy to
+                    distinguish different versions of the same TD</td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </section>
 
         <section>
           <h3 id="recommended-fields-thing">Recommended fields</h3>
-            <div class="rfc2119-assertion" id="profile-thing-recommended-fields-1">
+          <div class="rfc2119-assertion" id="profile-thing-recommended-fields-1">
             <p>
               The following metadata fields of a <a>Thing</a> SHOULD be contained in a compliant
               Thing Description:
@@ -1320,24 +1323,24 @@
                 <tr>
                   <td>support</td>
                   <td><code>anyURI</code></td>
-                  <td>Contact information to obtain further help on the TD. 
+                  <td>Contact information to obtain further help on the TD.
                     This could be a company website or an email address of customer support.</td>
                   <td>maintenance and developer documentation</td>
                 </tr>
               </tbody>
             </table>
-            </div>
-          </section>
+          </div>
+        </section>
 
-          <section>
-            <h5 id="recommended-practice-">Recommended practice</h5>
-         
-            <p><span class="rfc2119-assertion" id="profile-5-1-2-1-thing-mandatory-fields-1-z">
+        <section>
+          <h5 id="recommended-practice-">Recommended practice</h5>
+
+          <p><span class="rfc2119-assertion" id="profile-5-1-2-1-thing-mandatory-fields-1-z">
               It is RECOMMENDED to use the value
               &quot;&quot; for strings, where the
               value cannot be determined.</span>
-            </p>
-            <p><span class="rfc2119-assertion" id="profile-thing-recommended-fields-2">
+          </p>
+          <p><span class="rfc2119-assertion" id="profile-thing-recommended-fields-2">
               If a Thing Description is used solely within
               a company, the email address of the developer
               SHOULD be used in the support field.</span>
@@ -1362,17 +1365,17 @@
 
         <section class="ednote" TODO>
           The <code>format</code> field permits to define new schema types.
-          The profile needs to define, how mismatching types 
+          The profile needs to define, how mismatching types
           that are passed in as parameters or returned objects
           are handled, i.e. specify an error behavior.
         </section>
 
         <p>
-        The <a>Baseline Information Model</a> applies the following
-        constraints and rules to the
-        <code>DataSchema</code>
-        class of the <a>WoT Thing Description</a>
-        Specification</a>.
+          The <a>Baseline Information Model</a> applies the following
+          constraints and rules to the
+          <code>DataSchema</code>
+          class of the <a>WoT Thing Description</a>
+          Specification</a>.
         </p>
       </section>
 
@@ -1387,46 +1390,46 @@
         <section>
           <h4>Mandatory fields</h4>
           <div class="rfc2119-assertion" id="profile-thing-property-affordance-mandatory-fields-1">
-          <p>
+            <p>
               The following property fields MUST be contained
               in the
               <code>properties</code>
               element of a <em>Profile compliant TD</em>:
-          </p>
-          <table class="def">
-            <thead>
-              <tr>
-                <th>Keyword</th>
-                <th>Type</th>
-                <th>Constraints</th>
-                <th>Rationale</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>title</td>
-                <td><code>string</code></td>
-                <td>unique name among all
-                  properties</td>
+            </p>
+            <table class="def">
+              <thead>
+                <tr>
+                  <th>Keyword</th>
+                  <th>Type</th>
+                  <th>Constraints</th>
+                  <th>Rationale</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>title</td>
+                  <td><code>string</code></td>
+                  <td>unique name among all
+                    properties</td>
                   <td>unambigous UI labels</td>
-                  </tr>
-               <tr>
-                <td>type</td>
-                <td><code>string</code></td>
-                <td>
-                  <span class="rfc2119-assertion" id="profile-thing-property-affordance-mandatory-fields-2">
-                    one of <code>boolean</code>,
-                    <code> string </code>, <code>
+                </tr>
+                <tr>
+                  <td>type</td>
+                  <td><code>string</code></td>
+                  <td>
+                    <span class="rfc2119-assertion" id="profile-thing-property-affordance-mandatory-fields-2">
+                      one of <code>boolean</code>,
+                      <code> string </code>, <code>
                                           number </code>, <code> integer
                                       </code>, <code> object </code> or <code>
                                           array </code>. The type value <code>
                                           null </code> MUST NOT be used.
                     </span>
-                </td>
-                <td>well defined types</td>
-              </tr>
-            </tbody>
-          </table>
+                  </td>
+                  <td>well defined types</td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </section>
 
@@ -1438,143 +1441,144 @@
             object depths for properties. Parsing of a
             deeply nested structure may cause significant implementation complexity.
             <span class="rfc2119-assertion" id="profile-thing-property-affordance-additional-constraints-1">
-            Therefore each
-            property MUST NOT exceed a maximum depth
-	          of 5 levels of nested
-            <code>array</code>
-            or
-            <code>object</code>
-            elements.</span>
+              Therefore each
+              property MUST NOT exceed a maximum depth
+              of 5 levels of nested
+              <code>array</code>
+              or
+              <code>object</code>
+              elements.</span>
             <span class="rfc2119-assertion" id="profile-thing-property-affordance-additional-constraints-1b">
-	          It is RECOMMENDED to keep the nesting
-	          of 
-            <code>array</code>
-            or
-            <code>object</code>
-		        elements below 4.</span>
+              It is RECOMMENDED to keep the nesting
+              of
+              <code>array</code>
+              or
+              <code>object</code>
+              elements below 4.</span>
           </p>
 
           <div class="rfc2119-assertion" id="profile-thing-property-affordance-additional-constraints-2">
-          <p>
+            <p>
               The following additional constraints MUST be
               applied to the Property Affordances of a <em>Thing
                 Description</em> conforming to the <a>Baseline
                 Profile</a>:
-          </p>
-          <table class="def">
-            <thead>
-              <tr>
-                <th>Keyword</th>
-                <th>Type</th>
-                <th>Constraint</th>
-                <th>Rationale</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>const</td>
-                <td>anyType</td>
-                <td>
-                  <span class="rfc2119-assertion"
-                    id="profile-5-1-4-2-thing-property-affordance-additional-constraints-3-x">
-                    MUST NOT be used
-                  </span>
-                </td>
-              </tr>
-              <tr>
-                <td>enum</td>
-                <td>array of simple type</td>
-                <td>
-                  <span class="rfc2119-assertion"
-                    id="profile-5-1-4-2-thing-property-affordance-additional-constraints-4-x">
-                    <em>Values</em> of enums MAY
-                    only be simple types. Handling of <em>any
-                      type</em> is too complex to implement
-                    on resource constrained devices
-                  </span>
-                </td>
-              </tr>
+            </p>
+            <table class="def">
+              <thead>
+                <tr>
+                  <th>Keyword</th>
+                  <th>Type</th>
+                  <th>Constraint</th>
+                  <th>Rationale</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>const</td>
+                  <td>anyType</td>
+                  <td>
+                    <span class="rfc2119-assertion"
+                      id="profile-5-1-4-2-thing-property-affordance-additional-constraints-3-x">
+                      MUST NOT be used
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td>enum</td>
+                  <td>array of simple type</td>
+                  <td>
+                    <span class="rfc2119-assertion"
+                      id="profile-5-1-4-2-thing-property-affordance-additional-constraints-4-x">
+                      <em>Values</em> of enums MAY
+                      only be simple types. Handling of <em>any
+                        type</em> is too complex to implement
+                      on resource constrained devices
+                    </span>
+                  </td>
+                </tr>
                 <td>forms</td>
                 <td><code>array</code> of Forms</td>
                 <td>
                   <p>
-                  <span class="rfc2119-assertion" id="profile-thing-property-affordance-additional-constraints-5">
-                  For a single protocol the <code>Array of Form</code>
-                  of each property MUST contain only a
-                  <em>single endpoint</em> for each
-                  operation <code>readproperty</code>, 
-                  <code>writeproperty</code>, <code>observeproperty</code>,
-                  <code>unobserveproperty</code>.
-                  </span>
-                  </p><p>                  
-                  <span class="rfc2119-assertion" id="profile-thing-action-affordance-form-constraints-2-y">
-                    The value of <code>op</code> MUST be a single value.
-                    Arrays with combinations of these values are NOT PERMITTED.
-                  </span>
-                <!-- /p>
+                    <span class="rfc2119-assertion" id="profile-thing-property-affordance-additional-constraints-5">
+                      For a single protocol the <code>Array of Form</code>
+                      of each property MUST contain only a
+                      <em>single endpoint</em> for each
+                      operation <code>readproperty</code>,
+                      <code>writeproperty</code>, <code>observeproperty</code>,
+                      <code>unobserveproperty</code>.
+                    </span>
+                  </p>
+                  <p>
+                    <span class="rfc2119-assertion" id="profile-thing-action-affordance-form-constraints-2-y">
+                      The value of <code>op</code> MUST be a single value.
+                      Arrays with combinations of these values are NOT PERMITTED.
+                    </span>
+                    <!-- /p>
                 </td>
-                <td><p>If multiple endpoints for the same protocol are present, 
-                  a common selection algorithm has to be defined. 
-                  This may imply invoking form elements in sequence with 
-                  a trial and error method that can lead to significant 
-                  delays due to timeout handling obligations. 
+                <td><p>If multiple endpoints for the same protocol are present,
+                  a common selection algorithm has to be defined.
+                  This may imply invoking form elements in sequence with
+                  a trial and error method that can lead to significant
+                  delays due to timeout handling obligations.
                 </p>
                 <p>
                   Combination of operations are ambiguous and have very
                   complex interaction semantics.
                 </p-->
-              </td>
-              </tr>
-              <tr>
-                <td>format</td>
-                <td><code>string</code></td>
-                <td>
-                  <span class="rfc2119-assertion" id="profile-thing-property-affordance-additional-constraints-6">
-                  If the field <code>format</code>
-                  is used, only formats defined in
-                  section 7.3.1-7.3.6 of
-                  [[JSON-SCHEMA]] MUST be used.
-                  </span>
                 </td>
-                <td>Predictive finite set of choices.</td>
-              </tr>
-              <tr>
-                <td>oneOf</td>
-                <td>string</td>
-                <td>
-                  <span class="rfc2119-assertion"
-                    id="profile-5-1-4-2-thing-property-affordance-additional-constraints-7-x">
-                    The DataSchema field <code>oneOf</code>
-                    does not make sense for properties
-                    and MUST NOT be used.
-                  </span>
-                </td>
-              </tr>
-              <tr>
-                <td>uriVariables</td>
-                <td>Map of DataSchema</td>
-                <td>
-                  <span class="rfc2119-assertion" id="profile-thing-property-affordance-additional-constraints-8">
-                  <code>uriVariables</code> MUST
-                  NOT be used.
-                  </span>
+                </tr>
+                <tr>
+                  <td>format</td>
+                  <td><code>string</code></td>
+                  <td>
+                    <span class="rfc2119-assertion" id="profile-thing-property-affordance-additional-constraints-6">
+                      If the field <code>format</code>
+                      is used, only formats defined in
+                      section 7.3.1-7.3.6 of
+                      [[JSON-SCHEMA]] MUST be used.
+                    </span>
+                  </td>
+                  <td>Predictive finite set of choices.</td>
+                </tr>
+                <tr>
+                  <td>oneOf</td>
+                  <td>string</td>
+                  <td>
+                    <span class="rfc2119-assertion"
+                      id="profile-5-1-4-2-thing-property-affordance-additional-constraints-7-x">
+                      The DataSchema field <code>oneOf</code>
+                      does not make sense for properties
+                      and MUST NOT be used.
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td>uriVariables</td>
+                  <td>Map of DataSchema</td>
+                  <td>
+                    <span class="rfc2119-assertion" id="profile-thing-property-affordance-additional-constraints-8">
+                      <code>uriVariables</code> MUST
+                      NOT be used.
+                    </span>
                   <td>The semantic meaning of URI variables cannot be described in a TD in an unambiguous way.</td>
-                </td>
-              </tr>
+                  </td>
+                </tr>
 
-            </tbody>
-          </table>
+              </tbody>
+            </table>
           </div>
           <span class="rfc2119-assertion" id="profile-thing-action-affordance-additional-constraints-7">
             The DataSchema fields <code>default</code> and
             <code>oneOf</code>
             are undefined for properties and MUST NOT be used.</span>
-          </section>
+        </section>
 
         <section>
           <h4>Recommended Practice</h4>
           <div class="rfc2119-assertion" id="profile-property-recommended-practice">
-          <p>
+            <p>
               The following property fields SHOULD be contained in the <code>properties</code>
               element of a <em>Profile compliant TD</em>:
             </p>
@@ -1596,13 +1600,13 @@
                 </tr>
               </tbody>
             </table>
-            </div>
-            <p>
-              <span class="rfc2119-assertion" id="profile-thing-property-recommended-fields-2">
-                It is highly RECOMMENDED to always specify a
-                <code>unit</code>, if a value has a metric.</span>
-                Authors of <em>Thing Descriptions</em> should be aware that units
-                that are common in their geographic region are
+          </div>
+          <p>
+            <span class="rfc2119-assertion" id="profile-thing-property-recommended-fields-2">
+              It is highly RECOMMENDED to always specify a
+              <code>unit</code>, if a value has a metric.</span>
+            Authors of <em>Thing Descriptions</em> should be aware that units
+            that are common in their geographic region are
             not globally applicable and may lead to
             misinterpretation with drastic consequences.
           </p>
@@ -1621,7 +1625,7 @@
             <code>bin</code>
             ,
             to indicate how the value should be
-            interpreted. 
+            interpreted.
             <span class="rfc2119-assertion" id="profile-thing-properties-recommended-practice-2">
               It is strongly RECOMMENDED to use
               the values
@@ -1631,8 +1635,8 @@
               or
               <code>bin</code>
               in the <code>unit</code> for string values with binary or hex data to achieve interoperability.</span>
-            </p>
-            <!-- TODO: consider how to indicate specific types such as char, signed/unsigned short, ... -->
+          </p>
+          <!-- TODO: consider how to indicate specific types such as char, signed/unsigned short, ... -->
         </section>
       </section>
 
@@ -1649,28 +1653,28 @@
           <h4>Mandatory fields</h4>
 
           <div class="rfc2119-assertion" id="profile-thing-action-affordances-mandatory-fields-1">
-          <p>
+            <p>
               The following fields MUST be contained in an
               action element of an <a>Baseline Profile</a> compliant TD:
-          </p>
-          <table class="def">
-            <thead>
-              <tr>
-                <th>Keyword</th>
-                <th>Type</th>
-                <th>Constraints</th>
-                <th>Rationale</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>title</td>
-                <td><code>string</code></td>
-                <td>unique name among all actions</td>
-                <td>unambigous UI labels</td>
-               </tr>
-            </tbody>
-          </table>
+            </p>
+            <table class="def">
+              <thead>
+                <tr>
+                  <th>Keyword</th>
+                  <th>Type</th>
+                  <th>Constraints</th>
+                  <th>Rationale</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>title</td>
+                  <td><code>string</code></td>
+                  <td>unique name among all actions</td>
+                  <td>unambigous UI labels</td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </section>
 
@@ -1678,13 +1682,13 @@
           <h4>Additional Constraints</h4>
           <p>
             <span class="rfc2119-assertion" id="profile-thing-action-affordance-additional-constraints-1">
-            The following additional constraints MUST be
-            applied to the indicated fields of the Interaction Affordances of a <a>Thing
-              Description</a> conforming to the <a>Baseline
-              Information Model</a>:
+              The following additional constraints MUST be
+              applied to the indicated fields of the Interaction Affordances of a <a>Thing
+                Description</a> conforming to the <a>Baseline
+                Information Model</a>:
             </span>
           </p>
-             <table>
+          <table>
             <thead>
               <tr>
                 <th>Keyword</th>
@@ -1698,31 +1702,32 @@
                 <td>array of Forms</td>
                 <td>
                   <p><span class="rfc2119-assertion" id="profile-thing-action-affordance-form-constraints-1">
-                    For a single protocol the <code>array of Form</code>
-                    of each property MUST contain only a
-                    <em>single endpoint</em> for each
-                    operation.
+                      For a single protocol the <code>array of Form</code>
+                      of each property MUST contain only a
+                      <em>single endpoint</em> for each
+                      operation.
                     </span>
-                  </p><p>
+                  </p>
+                  <p>
                     <span class="rfc2119-assertion" id="profile-thing-action-affordance-form-constraints-2-x">
                       The value of <code>op</code> MUST be a single value.
                       Arrays with combinations of these values are NOT PERMITTED.
                     </span>
-                    </p>
+                  </p>
                 </td>
-                </tr>
-                <tr>
-                  <td>format</td>
-                  <td><code>string</code></td>
-                  <td>
-                    <span class="rfc2119-assertion" id="profile-thing-action-affordance-format-constraints">
+              </tr>
+              <tr>
+                <td>format</td>
+                <td><code>string</code></td>
+                <td>
+                  <span class="rfc2119-assertion" id="profile-thing-action-affordance-format-constraints">
                     If the field <code>format</code>
                     is used, only formats defined in
                     section 7.3.1-7.3.6 of
                     [[JSON-SCHEMA]] MUST be used.
-                    </span>
-                  </td>
-                  <td>Predictive finite set of choices.</td>
+                  </span>
+                </td>
+                <td>Predictive finite set of choices.</td>
               </tr>
               <tr>
                 <td>uriVariables</td>
@@ -1731,9 +1736,9 @@
                   <span class="rfc2119-assertion" id="profile-thing-action-affordance-uri-variables">
                     <code>uriVariables</code> MUST
                     NOT be used.
-                    </span>
-                    <td>The semantic meaning of URI variables cannot be described in a TD in an unambiguous way.</td>
-                  </td>
+                  </span>
+                <td>The semantic meaning of URI variables cannot be described in a TD in an unambiguous way.</td>
+                </td>
               </tr>
             </tbody>
           </table>
@@ -1773,43 +1778,43 @@
         <section>
           <h4>Additional Constraints</h4>
           <div class="rfc2119-assertion" id="profile-5-1-6-2-thing-event-affordance-additional-constrains-1-x">
-          <p>
+            <p>
               The following additional constraints MUST be
               applied to the Event Affordances of a <a>WoT Thing
                 Description</a> conforming to the profile:
-          </p>
-          <table class="def">
-            <thead>
-              <tr>
-                <th>keyword</th>
-                <th>type</th>
-                <th>constraint</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>forms</td>
-                <td>array of Forms</td>
-                <td>
-                  <span class="rfc2119-assertion" id="profile-5-1-6-2-thing-event-affordance-additional-constrains-2">
-                    The <code>Array of Form</code>
-                    of each event MUST contain only a <em>single</em>
-                    endpoint.
-                  </span>
-                </td>
-              </tr>
-              <tr>
-                <td>uriVariables</td>
-                <td>Map of DataSchema</td>
-                <td>
-                  <span class="rfc2119-assertion" id="profile-5-1-6-2-thing-event-affordance-additional-constrains-3">
-                    <code>uriVariables</code> MUST
-                    NOT be used.
-                  </span>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+            </p>
+            <table class="def">
+              <thead>
+                <tr>
+                  <th>keyword</th>
+                  <th>type</th>
+                  <th>constraint</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>forms</td>
+                  <td>array of Forms</td>
+                  <td>
+                    <span class="rfc2119-assertion" id="profile-5-1-6-2-thing-event-affordance-additional-constrains-2">
+                      The <code>Array of Form</code>
+                      of each event MUST contain only a <em>single</em>
+                      endpoint.
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td>uriVariables</td>
+                  <td>Map of DataSchema</td>
+                  <td>
+                    <span class="rfc2119-assertion" id="profile-5-1-6-2-thing-event-affordance-additional-constrains-3">
+                      <code>uriVariables</code> MUST
+                      NOT be used.
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </section>
       </section>
@@ -1818,50 +1823,51 @@
       <section id="forms">
         <h3>Forms</h3>
         <p>
-       </p>
+        </p>
         <section>
           <h4>Mandatory fields</h4>
           <div class="rfc2119-assertion" id="profile-thing-forms-mandatory-fields-1">
-          <p>
+            <p>
               The following fields MUST be present in a form
               element of a <em>Baseline TD</em>:
-          </p>
-          <table class="def">
-            <thead>
-              <tr>
-                <th>keyword</th>
-                <th>type</th>
-                <th>constraints</th>
-              </tr>
-            </thead>
-            <tbody>
-            </tbody>
-          </table>
+            </p>
+            <table class="def">
+              <thead>
+                <tr>
+                  <th>keyword</th>
+                  <th>type</th>
+                  <th>constraints</th>
+                </tr>
+              </thead>
+              <tbody>
+              </tbody>
+            </table>
           </div>
         </section>
         <section>
           <h4>Additional Constraints</h4>
           <div class="rfc2119-assertion" id="profile-5-1-7-2-thing-forms-additional-constraints-1-x">
-          <p>
+            <p>
               The following additional constraints MUST be
               applied to the Form elements of a <a>WoT Thing
                 Description</a> conforming to the <a>Baseline
                 profile</a>:
-          </p>
-          <table class="def">
-            <thead>
-              <tr>
-                <th>keyword</th>
-                <th>type</th>
-                <th>constraint</th>
-              </tr>
-            </thead>
-            <tbody>
-            </tbody>
-          </table>
+            </p>
+            <table class="def">
+              <thead>
+                <tr>
+                  <th>keyword</th>
+                  <th>type</th>
+                  <th>constraint</th>
+                </tr>
+              </thead>
+              <tbody>
+              </tbody>
+            </table>
           </div>
         </section>
       </section>
+    </section>
 
     <!-- Protocol Binding -->
     <section id="http-baseline-profile-protocol-binding">
@@ -1877,7 +1883,8 @@
       <p>
         <span class="rfc2119-assertion" id="profile-5-2-thing-protocol-binding-1">
           A Consumer or Web Thing conforming to the HTTP Baseline Profile
-          MUST implement this protocol binding.</span>
+          MUST implement this protocol binding.
+        </span>
       </p>
 
       <p>
@@ -1887,357 +1894,350 @@
       </p>
 
       <pre class="example">
-        {
-          "@context": "https://www.w3.org/2019/wot/td/v1",
-          "id": "https://mywebthingserver.com/things/lamp",
-          "profile": "https://www.w3.org/2022/wot/profile/http-baseline/v1",
-          "base": "https://mywebthingserver.com/things/lamp/",
-          "title": "My Lamp",
-          "description": "A web connected lamp",
-          "securityDefinitions": {
-            "oauth2": {
-              "scheme": "oauth2",
-              "flow": "code",
-              "authorization": "https://mywebthingserver.com/oauth/authorize",
-              "token": "https://mywebthingserver.com/oauth/token"
-            }
-          },
-          "security": "oauth2",
-          "properties": {
-            "on": {
-              "type": "boolean",
-              "title": "On/Off",
-              "description": "Whether the lamp is turned on",
-              "forms": [{"href": "properties/on"}]
+          {
+            "@context": "https://www.w3.org/2019/wot/td/v1",
+            "id": "https://mywebthingserver.com/things/lamp",
+            "profile": "https://www.w3.org/2022/wot/profile/http-baseline/v1",
+            "base": "https://mywebthingserver.com/things/lamp/",
+            "title": "My Lamp",
+            "description": "A web connected lamp",
+            "securityDefinitions": {
+              "oauth2": {
+                "scheme": "oauth2",
+                "flow": "code",
+                "authorization": "https://mywebthingserver.com/oauth/authorize",
+                "token": "https://mywebthingserver.com/oauth/token"
+              }
             },
-            "level" : {
-              "type": "integer",
-              "title": "Brightness",
-              "description": "The level of light from 0-100",
-              "unit": "percent",
-              "minimum" : 0,
-              "maximum" : 100,
-              "forms": [{"href": "properties/level"}]
-            }
-          },
-          "actions": {
-            "fade": {
-              "title": "Fade",
-              "description": "Fade the lamp to a given level",
-              "input": {
-                "type": "object",
-                "properties": {
-                  "level": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 100,
-                    "unit": "percent"
-                  },
-                  "duration": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "unit": "milliseconds"
-                  }
-                }
+            "security": "oauth2",
+            "properties": {
+              "on": {
+                "type": "boolean",
+                "title": "On/Off",
+                "description": "Whether the lamp is turned on",
+                "forms": [{"href": "properties/on"}]
               },
-              "forms": [{"href": "actions/fade"}]
-            }
-          },
-          "forms": [
-            {
-              "op": ["readallproperties", "writemultipleproperties"],
-              "href": "properties"
+              "level" : {
+                "type": "integer",
+                "title": "Brightness",
+                "description": "The level of light from 0-100",
+                "unit": "percent",
+                "minimum" : 0,
+                "maximum" : 100,
+                "forms": [{"href": "properties/level"}]
+              }
             },
-            {
-              "op": "queryallactions",
-              "href": "actions"
-            }
-          ]
-        }
-      </pre>
+            "actions": {
+              "fade": {
+                "title": "Fade",
+                "description": "Fade the lamp to a given level",
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "level": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 100,
+                      "unit": "percent"
+                    },
+                    "duration": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "unit": "milliseconds"
+                    }
+                  }
+                },
+                "forms": [{"href": "actions/fade"}]
+              }
+            },
+            "forms": [
+              {
+                "op": ["readallproperties", "writemultipleproperties"],
+                "href": "properties"
+              },
+              {
+                "op": "queryallactions",
+                "href": "actions"
+              }
+            ]
+          }
+        </pre>
 
       <section id="http-baseline-profile-protocol-binding-properties">
         <h4>Properties</h4>
         <section id="http-baseline-profile-protocol-binding-readproperty">
           <h5><code>readproperty</code></h5>
-	  <div class="rfc2119-assertion"
-            id="http-baseline-profile-protocol-binding-readproperty-1">
-	  <p>
-            The URL of a <code>Property</code> resource to be used when reading
-            the value of a property MUST be obtained from a Thing Description by
-            locating a
-            <a href="https://www.w3.org/TR/wot-thing-description/#form">
-              <code>Form</code></a> inside the corresponding
-            <a href="https://www.w3.org/TR/wot-thing-description/#propertyaffordance">
-              <code>PropertyAffordance</code></a>
-            for which:
-	  </p>
-	 <ul>
-            <li>
-              After defaults have been applied, its <code>op</code> member
-              contains the value <code>readproperty</code>.
-            </li>
-            <li>
-              After being resolved against a base URL where applicable, the
-              <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
-                scheme</a> [[RFC3986]] of the value of its <code>href</code>
-              member is <code>http</code> or <code>https</code>
-            </li>
-          </ul>
-	  </div>
-	  <p><span class="rfc2119-assertion"
-          id="http-baseline-profile-protocol-binding-readproperty-3">
-            The resolved value of the <code>href</code> member MUST then be used
-            as the URL of the <code>Property</code> resource.</span></p>
-	  <div class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-readproperty-4">
-	  <p>
-            In order to read the value of a property, a Consumer MUST send
-            an HTTP request to a Web Thing with:
-	  </p>
-	  <ul>
-            <li>Method set to <code>GET</code></li>
-            <li>URL set to the URL of the <code>Property</code> resource</li>
-            <li><code>Accept</code> header set to <code>application/json
-              </code></li>
-          </ul>
-	  </div>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-readproperty-1">
+            <p>
+              The URL of a <code>Property</code> resource to be used when reading
+              the value of a property MUST be obtained from a Thing Description by
+              locating a
+              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+                <code>Form</code></a> inside the corresponding
+              <a href="https://www.w3.org/TR/wot-thing-description/#propertyaffordance">
+                <code>PropertyAffordance</code></a>
+              for which:
+            </p>
+            <ul>
+              <li>
+                After defaults have been applied, its <code>op</code> member
+                contains the value <code>readproperty</code>.
+              </li>
+              <li>
+                After being resolved against a base URL where applicable, the
+                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                  scheme</a> [[RFC3986]] of the value of its <code>href</code>
+                member is <code>http</code> or <code>https</code>
+              </li>
+            </ul>
+          </div>
+          <p><span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-readproperty-3">
+              The resolved value of the <code>href</code> member MUST then be used
+              as the URL of the <code>Property</code> resource.</span>
+          </p>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-readproperty-4">
+            <p>
+              In order to read the value of a property, a Consumer MUST send
+              an HTTP request to a Web Thing with:
+            </p>
+            <ul>
+              <li>Method set to <code>GET</code></li>
+              <li>URL set to the URL of the <code>Property</code> resource</li>
+              <li><code>Accept</code> header set to <code>application/json
+                </code></li>
+            </ul>
+          </div>
           <pre class="example">
-          GET /things/lamp/properties/on HTTP/1.1
-          Host: mythingserver.com
-          Accept: application/json
-          </pre>
-	  <div class="rfc2119-assertion"
-            id="http-baseline-profile-protocol-binding-readproperty-6">
-	  <p>
-            If a Web Thing receives an HTTP request following the format
-            above and the Consumer has permission to read the corresponding
-            property, then upon successfully reading the value of the property
-            it MUST send an HTTP response with:
-          <ul>
-            <li>Status code set to <code>200</code></li>
-            <li><code>Content-Type</code> header set to <code>application/json
-              </code></li>
-            <li>A body with the value of the property serialized in JSON</li>
-          </ul>
-	  </div>
+              GET /things/lamp/properties/on HTTP/1.1
+              Host: mythingserver.com
+              Accept: application/json
+            </pre>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-readproperty-6">
+            <p>
+              If a Web Thing receives an HTTP request following the format
+              above and the Consumer has permission to read the corresponding
+              property, then upon successfully reading the value of the property
+              it MUST send an HTTP response with:
+            </p>
+            <ul>
+              <li>Status code set to <code>200</code></li>
+              <li><code>Content-Type</code> header set to <code>application/json
+                </code></li>
+              <li>A body with the value of the property serialized in JSON</li>
+            </ul>
+          </div>
           <pre class="example">
-          HTTP/1.1 200 OK
-          Content-Type: application/json
-          false
+            HTTP/1.1 200 OK
+            Content-Type: application/json
+            false
           </pre>
         </section>
         <section id="http-baseline-profile-protocol-binding-writeproperty">
           <h5><code>writeproperty</code></h5>
-	  <div class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-writeproperty-1">
-	  <p>
-            The URL of a <code>Property</code> resource to be used when writing
-            the value of a property MUST be obtained from a Thing Description by
-            locating a
-            <a href="https://www.w3.org/TR/wot-thing-description/#form">
-              <code>Form</code></a> inside the corresponding
-            <a href="https://www.w3.org/TR/wot-thing-description/#propertyaffordance">
-              <code>PropertyAffordance</code></a>
-            for which:
-	  </p>
-	  <ul>
-            <li>
-              After defaults have been applied, its <code>op</code> member
-              contains the value <code>writeproperty</code>
-            </li>
-            <li>
-              After being resolved against a base URL where applicable, the
-              <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
-                scheme</a> [[RFC3986]] of the value of its <code>href</code>
-              member is <code>http</code> or <code>https</code>
-            </li>
-          </ul>
-	  </div>
-	  <p><span class="rfc2119-assertion" 
-          id="http-baseline-profile-protocol-binding-writeproperty-3">
-            The resolved value of the <code>href</code> member MUST then be used
-            as the URL of the <code>Property</code> resource.</span></p>
-	  <div class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-writeproperty-4">
-	  <p>
-            In order to write the value of a property, a Consumer MUST send
-            an HTTP request to a Web Thing with:
-	  </p>
-	  <ul>
-            <li>Method set to <code>PUT</code></li>
-            <li>URL set to the URL of the <code>Property</code> resource</li>
-            <li><code>Content-Type</code> header set to <code>application/json
-              </code></li>
-            <li>A body with a requested new value for the property serialized
-              in JSON</li>
-          </ul>
-	  </div>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-writeproperty-1">
+            <p>
+              The URL of a <code>Property</code> resource to be used when writing
+              the value of a property MUST be obtained from a Thing Description by
+              locating a
+              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+                <code>Form</code></a> inside the corresponding
+              <a href="https://www.w3.org/TR/wot-thing-description/#propertyaffordance">
+                <code>PropertyAffordance</code></a>
+              for which:
+            </p>
+            <ul>
+              <li>
+                After defaults have been applied, its <code>op</code> member
+                contains the value <code>writeproperty</code>
+              </li>
+              <li>
+                After being resolved against a base URL where applicable, the
+                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                  scheme</a> [[RFC3986]] of the value of its <code>href</code>
+                member is <code>http</code> or <code>https</code>
+              </li>
+            </ul>
+          </div>
+          <p><span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-writeproperty-3">
+              The resolved value of the <code>href</code> member MUST then be used
+              as the URL of the <code>Property</code> resource.</span></p>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-writeproperty-4">
+            <p>
+              In order to write the value of a property, a Consumer MUST send
+              an HTTP request to a Web Thing with:
+            </p>
+            <ul>
+              <li>Method set to <code>PUT</code></li>
+              <li>URL set to the URL of the <code>Property</code> resource</li>
+              <li><code>Content-Type</code> header set to <code>application/json
+                </code></li>
+              <li>A body with a requested new value for the property serialized
+                in JSON</li>
+            </ul>
+          </div>
           <pre class="example">
-          PUT /things/lamp/properties/on HTTP/1.1
-          Host: mythingserver.com
-          Content-Type: application/json
-          true
+            PUT /things/lamp/properties/on HTTP/1.1
+            Host: mythingserver.com
+            Content-Type: application/json
+            true
           </pre>
-	  <div class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-writeproperty-6">
-	  <p>
-            If a Web Thing receives an HTTP request following the format
-            above and the Consumer has permission to write the corresponding
-            property, then upon successfully writing the value of the
-            property it MUST send an HTTP response with:
-	  <ul>
-            <li>Status code set to <code>204</code></li>
-          </ul>
-	  </div>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-writeproperty-6">
+            <p>
+              If a Web Thing receives an HTTP request following the format
+              above and the Consumer has permission to write the corresponding
+              property, then upon successfully writing the value of the
+              property it MUST send an HTTP response with:
+            </p>
+            <ul>
+              <li>Status code set to <code>204</code></li>
+            </ul>
+          </div>
           <pre class="example">
-          HTTP/1.1 204 No Content
+            HTTP/1.1 204 No Content
           </pre>
         </section>
         <section id="http-baseline-profile-protocol-binding-readallproperties">
           <h5><code>readallproperties</code></h5>
-	  <div class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-readallproperties-1">
-	  <p>
-            The URL of a <code>Properties</code> resource to be used when
-            reading the value of all properties at once MUST be obtained from a
-            Thing Description by locating a
-            <a href="https://www.w3.org/TR/wot-thing-description/#form">
-              <code>Form</code></a> inside the top level
-            <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json">
-              <code>forms</code></a> member
-            for which:
-	  </p>
-	  <ul>
-            <li>
-              Its <code>op</code> member contains the value
-              <code>readallproperties</code>
-            </li>
-            <li>
-              After being resolved against a base URL where applicable, the
-              <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
-                scheme</a> [[RFC3986]] of the value of its <code>href</code>
-              member is <code>http</code> or <code>https</code>
-            </li>
-          </ul>
-	  </div>
-	  <p><span class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-readallproperties-3">
-            The resolved value of the <code>href</code> member MUST then be used
-            as the URL of the <code>Properties</code> resource.</span></p>
-	  <div class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-readallproperties-4">
-	  <p>
-            In order to read the value of all properties, a Consumer MUST send
-            an HTTP request to a Web Thing with:
-	  </p>
-	  <ul>
-            <li>Method set to <code>GET</code></li>
-            <li>URL set to the URL of the <code>Properties</code> resource
-            </li>
-            <li><code>Accept</code> header set to <code>application/json
-              </code></li>
-          </ul>
-	  </div>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-readallproperties-1">
+            <p>
+              The URL of a <code>Properties</code> resource to be used when
+              reading the value of all properties at once MUST be obtained from a
+              Thing Description by locating a
+              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+                <code>Form</code></a> inside the top level
+              <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json">
+                <code>forms</code></a> member
+              for which:
+            </p>
+            <ul>
+              <li>
+                Its <code>op</code> member contains the value
+                <code>readallproperties</code>
+              </li>
+              <li>
+                After being resolved against a base URL where applicable, the
+                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                  scheme</a> [[RFC3986]] of the value of its <code>href</code>
+                member is <code>http</code> or <code>https</code>
+              </li>
+            </ul>
+          </div>
+          <p>
+            <span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-readallproperties-3">
+              The resolved value of the <code>href</code> member MUST then be used
+              as the URL of the <code>Properties</code> resource.
+            </span>
+          </p>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-readallproperties-4">
+            <p>
+              In order to read the value of all properties, a Consumer MUST send
+              an HTTP request to a Web Thing with:
+            </p>
+            <ul>
+              <li>Method set to <code>GET</code></li>
+              <li>URL set to the URL of the <code>Properties</code> resource
+              </li>
+              <li><code>Accept</code> header set to <code>application/json
+                  </code></li>
+            </ul>
+          </div>
           <pre class="example">
-          GET /things/lamp/properties HTTP/1.1
-          Host: mythingserver.com
-          Accept: application/json
-          </pre>
-	  <div class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-readallproperties-5">
-	  <p>
-            If a Web Thing receives an HTTP request following the format
-            above, then upon successfully reading the values of all the
-            readable properties to which the Consumer has permission to
-            access, it MUST send an HTTP response with:
-	  </p>
-	  <ul>
-            <li>Status code set to <code>200</code></li>
-            <li><code>Content-Type</code> header set to <code>application/json
-              </code></li>
-            <li>A body with the values of all readable properties serialized
-              in JSON, as an object keyed by property name</li>
-          </ul>
-	  </div>
+              GET /things/lamp/properties HTTP/1.1
+              Host: mythingserver.com
+              Accept: application/json
+            </pre>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-readallproperties-5">
+            <p>
+              If a Web Thing receives an HTTP request following the format
+              above, then upon successfully reading the values of all the
+              readable properties to which the Consumer has permission to
+              access, it MUST send an HTTP response with:
+            </p>
+            <ul>
+              <li>Status code set to <code>200</code></li>
+              <li><code>Content-Type</code> header set to <code>application/json
+                  </code></li>
+              <li>A body with the values of all readable properties serialized
+                in JSON, as an object keyed by property name</li>
+            </ul>
+          </div>
           <pre class="example">
-          HTTP/1.1 200 OK
-          Content-Type: application/json
-          {
-            "on": false,
-            "level": 100
-          }
-          </pre>
+              HTTP/1.1 200 OK
+              Content-Type: application/json
+              {
+                "on": false,
+                "level": 100
+              }
+            </pre>
         </section>
         <section id="http-baseline-profile-protocol-binding-writemultipleproperties">
           <h5><code>writemultipleproperties</code></h5>
-	  <div class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-writemultipleproperties-1">
-	  <p>
-            The URL of a <code>Properties</code> resource to be used when 
-            writing the value of multiple properties at once MUST be obtained
-            from a Thing Description by locating a
-            <a href="https://www.w3.org/TR/wot-thing-description/#form">
-              <code>Form</code></a> inside the top level
-            <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json">
-              <code>forms</code></a> member
-            for which:
-	  </p>
-         <ul>
-            <li>
-              Its <code>op</code> member contains the value
-              <code>writemultipleproperties</code>
-            </li>
-            <li>
-              After being resolved against a base URL where applicable, the
-              <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
-                scheme</a> [[RFC3986]] of the value of its <code>href</code>
-              member is <code>http</code> or <code>https</code>
-            </li>
-          </ul>
-	  </div>
-	  <p><span class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-bindings-writemultipleproperties-3">
-            The resolved value of the <code>href</code> member MUST then be used
-            as the URL of the <code>Properties</code> resource.</span></p>
-	  <div class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-writemultipleproperties-4">
-	  <p>
-            In order to write the value of multiple properties at once, a
-            Consumer MUST send an HTTP request to a Web Thing with:
-	  </p>
-	  <ul>
-            <li>Method set to <code>PUT</code></li>
-            <li>URL set to the URL of the <code>Properties</code> resource
-            </li>
-            <li><code>Content-Type</code> header set to <code>application/json
-              </code></li>
-            <li>A body with requested new values for the writable properties
-              serialized in JSON, as an object keyed by property name</li>
-          </ul>
-	  </div>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-writemultipleproperties-1">
+            <p>
+              The URL of a <code>Properties</code> resource to be used when
+              writing the value of multiple properties at once MUST be obtained
+              from a Thing Description by locating a
+              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+                <code>Form</code></a> inside the top level
+              <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json">
+                <code>forms</code></a> member
+              for which:
+            </p>
+            <ul>
+              <li>
+                Its <code>op</code> member contains the value
+                <code>writemultipleproperties</code>
+              </li>
+              <li>
+                After being resolved against a base URL where applicable, the
+                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                  scheme</a> [[RFC3986]] of the value of its <code>href</code>
+                member is <code>http</code> or <code>https</code>
+              </li>
+            </ul>
+          </div>
+          <p>
+            <span class="rfc2119-assertion" id="http-baseline-profile-protocol-bindings-writemultipleproperties-3">
+              The resolved value of the <code>href</code> member MUST then be used
+              as the URL of the <code>Properties</code> resource.
+            </span>
+          </p>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-writemultipleproperties-4">
+            <p>
+              In order to write the value of multiple properties at once, a
+              Consumer MUST send an HTTP request to a Web Thing with:
+            </p>
+            <ul>
+              <li>Method set to <code>PUT</code></li>
+              <li>URL set to the URL of the <code>Properties</code> resource
+              </li>
+              <li><code>Content-Type</code> header set to <code>application/json
+                </code></li>
+              <li>A body with requested new values for the writable properties
+                serialized in JSON, as an object keyed by property name</li>
+            </ul>
+          </div>
           <pre class="example">
-          PUT /things/lamp/properties HTTP/1.1
-          Host: mythingserver.com
-          Content-Type: application/json
-          {
-            "on": true,
-            "level": 50
-          }
+            PUT /things/lamp/properties HTTP/1.1
+            Host: mythingserver.com
+            Content-Type: application/json
+            {
+              "on": true,
+              "level": 50
+            }
           </pre>
-	  <div class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-writemultipleproperties-6">
-	  <p>
-            If a Web Thing receives an HTTP request following the format
-            above, then upon successfully writing the values of the requested
-            writable properties it MUST send an HTTP response with:
-	  </p>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-writemultipleproperties-6">
+            <p>
+              If a Web Thing receives an HTTP request following the format
+              above, then upon successfully writing the values of the requested
+              writable properties it MUST send an HTTP response with:
+            </p>
             <ul>
               <li>Status code set to <code>204</code></li>
             </ul>
-	  </div>
+          </div>
           <pre class="example">
-          HTTP/1.1 204 No Content
+            HTTP/1.1 204 No Content
           </pre>
         </section>
         <section class="ednote">
@@ -2255,51 +2255,48 @@
         <h4>Actions</h4>
         <section id="http-baseline-profile-protocol-binding-invokeaction">
           <h5><code>invokeaction</code></h5>
-	  <div class="rfc2119-assertion"
-            id="http-baseline-profile-protocol-binding-invokeaction-1">
-	  <p>
-            The URL of an <code>Action</code> resource to be used when invoking
-            an action MUST be obtained from a Thing Description by locating a
-            <a href="https://www.w3.org/TR/wot-thing-description/#form">
-              <code>Form</code></a> inside the corresponding
-            <a href="https://www.w3.org/TR/wot-thing-description/#actionaffordance">
-              <code>ActionAffordance</code></a>
-            for which:
-	  </p>
-	 <ul>
-            <li>
-              After defaults have been applied, the value of its
-              <code>op</code> member is <code>invokeaction</code>
-            </li>
-            <li>
-              After being resolved against a base URL where applicable, the
-              <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
-                scheme</a> [[RFC3986]] of the value of its <code>href</code>
-              member is <code>http</code> or <code>https</code>
-            </li>
-          </ul>
-	  </div>
-	  <p><span class="rfc2119-assertion"
-            id="http-baseline-profile-protocol-binding-invokeaction-3">
-            The resolved value of the <code>href</code> member MUST then be used
-            as the URL of the <code>Action</code> resource.</span></p>
-	  <div class="rfc2119-assertion"
-            id="http-baseline-profile-protocol-binding-invokeaction-4">
-	  <p>
-            In order to invoke an action on a Web Thing, a Consumer MUST send
-            an HTTP request to the Web Thing with:
-	  </p>
-	  <ul>
-            <li>Method set to <code>POST</code></li>
-            <li>URL set to the URL of the <code>Action</code> resource</li>
-            <li><code>Accept</code> header set to <code>application/json
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-invokeaction-1">
+            <p>
+              The URL of an <code>Action</code> resource to be used when invoking
+              an action MUST be obtained from a Thing Description by locating a
+              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+                <code>Form</code></a> inside the corresponding
+              <a href="https://www.w3.org/TR/wot-thing-description/#actionaffordance">
+                <code>ActionAffordance</code></a>
+              for which:
+            </p>
+            <ul>
+              <li>
+                After defaults have been applied, the value of its
+                <code>op</code> member is <code>invokeaction</code>
+              </li>
+              <li>
+                After being resolved against a base URL where applicable, the
+                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                  scheme</a> [[RFC3986]] of the value of its <code>href</code>
+                member is <code>http</code> or <code>https</code>
+              </li>
+            </ul>
+          </div>
+          <p><span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-invokeaction-3">
+              The resolved value of the <code>href</code> member MUST then be used
+              as the URL of the <code>Action</code> resource.</span></p>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-invokeaction-4">
+            <p>
+              In order to invoke an action on a Web Thing, a Consumer MUST send
+              an HTTP request to the Web Thing with:
+            </p>
+            <ul>
+              <li>Method set to <code>POST</code></li>
+              <li>URL set to the URL of the <code>Action</code> resource</li>
+              <li><code>Accept</code> header set to <code>application/json
               </code></li>
-            <li><code>Content-Type</code> header set to <code>application/json
+              <li><code>Content-Type</code> header set to <code>application/json
               </code></li>
-            <li>A body with an input to the action, if any, serialized in
-              JSON</li>
-          </ul>
-	  </div>
+              <li>A body with an input to the action, if any, serialized in
+                JSON</li>
+            </ul>
+          </div>
           <pre class="example">
           POST /things/lamp/actions/fade HTTP/1.1
           Host: mythingserver.com
@@ -2310,176 +2307,169 @@
             "duration": 5
           }
           </pre>
-	  <div class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-invokeaction-6">
-	  <p>
-            If a Web Thing receives an HTTP request following the format
-            above then it MUST respond with one of three response formats:
-	  </p>
-          <ol>
-            <li>
-              <a href="#sync-action-response">Synchronous Action Response</a>
-            </li>
-            <li>
-              <a href="#async-action-response">Asynchronous Action Response</a>
-            </li>
-            <li>
-              <a href="#error-responses">Error Response</a>
-            </li>
-          </ol>
-	  </div>
-	  <p><span class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-invokeaction-8">
-            For long-running actions which are not expected to finish executing
-            within the timeout period of an HTTP request (e.g. 30 to 120
-            seconds), it is RECOMMENDED that a Web Thing respond with an
-            Asynchronous Action Response so that a Consumer may continue to
-            monitor the status of an action request with a
-            <code>queryaction</code> operation on a dynamically created
-            <code>ActionStatus</code> resource, after the initial
-            <code>invokeaction</code> response.</span></p>
-	  <p><span class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-invokeaction-9">
-            For short-lived actions which are expected to finish executing
-            within the timeout period of an HTTP request, a Web Thing MAY wait
-            until the action has completed to send a Synchronous Action
-            Response.</span></p>
-	  <p><span class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-invokeaction-10">
-            If a Web Thing encounters an error in attempting to execute an
-            action before responding to the <code>invokeaction</code> request,
-            then it MUST send an Error Response.</span></p>
-	  <p><span class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-invokeaction-11a">
-            Conforming Consumers MUST support all three types of response 
-            to the initial <code>invokeaction</code> request.</span>
-	  <span class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-invokeaction-11b">
-	    After the initial request,
-            support for subsequent operations on an <code>ActionStatus</code>
-            resource is OPTIONAL.</span></p>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-invokeaction-6">
+            <p>
+              If a Web Thing receives an HTTP request following the format
+              above then it MUST respond with one of three response formats:
+            </p>
+            <ol>
+              <li>
+                <a href="#sync-action-response">Synchronous Action Response</a>
+              </li>
+              <li>
+                <a href="#async-action-response">Asynchronous Action Response</a>
+              </li>
+              <li>
+                <a href="#error-responses">Error Response</a>
+              </li>
+            </ol>
+          </div>
+          <p><span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-invokeaction-8">
+              For long-running actions which are not expected to finish executing
+              within the timeout period of an HTTP request (e.g. 30 to 120
+              seconds), it is RECOMMENDED that a Web Thing respond with an
+              Asynchronous Action Response so that a Consumer may continue to
+              monitor the status of an action request with a
+              <code>queryaction</code> operation on a dynamically created
+              <code>ActionStatus</code> resource, after the initial
+              <code>invokeaction</code> response.</span></p>
+          <p><span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-invokeaction-9">
+              For short-lived actions which are expected to finish executing
+              within the timeout period of an HTTP request, a Web Thing MAY wait
+              until the action has completed to send a Synchronous Action
+              Response.</span></p>
+          <p><span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-invokeaction-10">
+              If a Web Thing encounters an error in attempting to execute an
+              action before responding to the <code>invokeaction</code> request,
+              then it MUST send an Error Response.</span></p>
+          <p><span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-invokeaction-11a">
+              Conforming Consumers MUST support all three types of response
+              to the initial <code>invokeaction</code> request.</span>
+            <span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-invokeaction-11b">
+              After the initial request,
+              support for subsequent operations on an <code>ActionStatus</code>
+              resource is OPTIONAL.</span>
+          </p>
 
           <h6 id="ActionStatus"><code>ActionStatus</code> object</h6>
-	  <div class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-invokeaction-12">
-	  <p>
-            The status of an action invocation request is represented by an 
-            <code>ActionStatus</code> object which includes the following 
-            members:
-	  </p>
-          <table class="def">
-            <thead>
-              <tr>
-                <th>Member</th>
-                <th>Description</th>
-                <th>Assignment</th>
-                <th>Type</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr class="rfc2119-table-assertion" id="http-baseline-profile-protocol-binding-invokeaction-12_1">
-                <td><code>status</code></td>
-                <td>The status of the action request.</td>
-                <td>mandatory</td>
-                <td>
-                  <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string">
-                    <code>string</code></a> (one of <code>pending</code>,
-                  <code>running</code>, <code>completed</code> or
-                  <code>failed</code>)
-                </td>
-              </tr>
-              <tr class="rfc2119-table-assertion" id="http-baseline-profile-protocol-binding-invokeaction-12_2">
-                <td><code>output</code></td>
-                <td>
-                  The output data, if any, of a completed action which
-                  MUST conform with the <code>output</code> data schema of the
-                  corresponding
-                  <a href="https://www.w3.org/TR/wot-thing-description/#actionaffordance">
-                    <code>ActionAffordance</code></a>.
-                </td>
-                <td>optional</td>
-                <td>any type</td>
-              </tr>
-              <tr class="rfc2119-table-assertion" id="http-baseline-profile-protocol-binding-invokeaction-12_3">
-                <td><code>error</code></td>
-                <td>
-                  An error message, if any, associated with a failed action
-                  which MUST use the JSON serialization of the Problem Details
-                  format [[RFC7807]] (only needed in response to a
-                  <a href="#http-baseline-profile-protocol-binding-queryaction"><code>queryaction</code></a>
-                  operation).
-                </td>
-                <td>optional</td>
-                <td><code>object</code></td>
-              </tr>
-              <tr class="rfc2119-table-assertion" id="http-baseline-profile-protocol-binding-invokeaction-12_4">
-                <td><code>href</code></td>
-                <td>
-                  The [[URL]] of an <code>ActionStatus</code> resource which can
-                  be polled with a <code>queryaction</code> operation to get
-                  the latest status of the action, the
-                  <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
-                    scheme</a> [[RFC3986]] of which MUST resolve to
-                  <code>http</code> or <code>https</code> (only needed for an
-                  <a href="#async-action-response">Asynchronous Action
-                    Response</a>).
-                </td>
-                <td>optional</td>
-                <td><code>string</code></td>
-              </tr>
-              <tr class="rfc2119-table-assertion">
-                <td><code>timeRequested</code></td>
-                <td>
-                  A timestamp indicating the time at which the Thing received 
-                  the request to execute the action, in ISO format [[ISO8601-1]]
-                  (see <a href="#date-format">Date format</a> for additional 
-                  constraints).
-                </td>
-                <td>optional</td>
-                <td><code>string</code></td>
-              </tr>
-              <tr class="rfc2119-table-assertion">
-                <td><code>timeEnded</code></td>
-                <td>
-                  A timestamp indicating the time at which the Thing
-                  successfully completed executing the action, or failed to 
-                  execute the action, in ISO format [[ISO8601-1]]
-                  (see <a href="#date-format">Date format</a> for additional 
-                  constraints).
-                </td>
-                <td>optional</td>
-                <td><code>string</code></td>
-              </tr>
-            </tbody>
-          </table>
-	        </div> 
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-invokeaction-12">
+            <p>
+              The status of an action invocation request is represented by an
+              <code>ActionStatus</code> object which includes the following
+              members:
+            </p>
+            <table class="def">
+              <thead>
+                <tr>
+                  <th>Member</th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="http-baseline-profile-protocol-binding-invokeaction-12_1">
+                  <td><code>status</code></td>
+                  <td>The status of the action request.</td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string">
+                      <code>string</code></a> (one of <code>pending</code>,
+                    <code>running</code>, <code>completed</code> or
+                    <code>failed</code>)
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="http-baseline-profile-protocol-binding-invokeaction-12_2">
+                  <td><code>output</code></td>
+                  <td>
+                    The output data, if any, of a completed action which
+                    MUST conform with the <code>output</code> data schema of the
+                    corresponding
+                    <a href="https://www.w3.org/TR/wot-thing-description/#actionaffordance">
+                      <code>ActionAffordance</code></a>.
+                  </td>
+                  <td>optional</td>
+                  <td>any type</td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="http-baseline-profile-protocol-binding-invokeaction-12_3">
+                  <td><code>error</code></td>
+                  <td>
+                    An error message, if any, associated with a failed action
+                    which MUST use the JSON serialization of the Problem Details
+                    format [[RFC7807]] (only needed in response to a
+                    <a href="#http-baseline-profile-protocol-binding-queryaction"><code>queryaction</code></a>
+                    operation).
+                  </td>
+                  <td>optional</td>
+                  <td><code>object</code></td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="http-baseline-profile-protocol-binding-invokeaction-12_4">
+                  <td><code>href</code></td>
+                  <td>
+                    The [[URL]] of an <code>ActionStatus</code> resource which can
+                    be polled with a <code>queryaction</code> operation to get
+                    the latest status of the action, the
+                    <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                      scheme</a> [[RFC3986]] of which MUST resolve to
+                    <code>http</code> or <code>https</code> (only needed for an
+                    <a href="#async-action-response">Asynchronous Action
+                      Response</a>).
+                  </td>
+                  <td>optional</td>
+                  <td><code>string</code></td>
+                </tr>
+                <tr class="rfc2119-table-assertion">
+                  <td><code>timeRequested</code></td>
+                  <td>
+                    A timestamp indicating the time at which the Thing received
+                    the request to execute the action, in ISO format [[ISO8601-1]]
+                    (see <a href="#date-format">Date format</a> for additional
+                    constraints).
+                  </td>
+                  <td>optional</td>
+                  <td><code>string</code></td>
+                </tr>
+                <tr class="rfc2119-table-assertion">
+                  <td><code>timeEnded</code></td>
+                  <td>
+                    A timestamp indicating the time at which the Thing
+                    successfully completed executing the action, or failed to
+                    execute the action, in ISO format [[ISO8601-1]]
+                    (see <a href="#date-format">Date format</a> for additional
+                    constraints).
+                  </td>
+                  <td>optional</td>
+                  <td><code>string</code></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
 
           <p class="note">
-            It is possible that a Thing's clock may not be set to the correct 
+            It is possible that a Thing's clock may not be set to the correct
             time. If timings are important then a Consumer may therefore choose
-            to treat the <code>timeEnded</code> member of an 
+            to treat the <code>timeEnded</code> member of an
             <code>ActionStatus</code> object as being relative to the
             <code>timeRequested</code> member, but not necessarily as relative
             to its own internal clock, or the clocks of other Things.
           </p>
 
           <h6 id="sync-action-response">Synchronous Action Response</h6>
-	  <div class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-invokeaction-13">
-		  <p>
-            If providing a Synchronous Action Response, a Web Thing MUST send 
-            an HTTP response with:
-	  </p>
-          <ul>
-            <li>Status code set to <code>200</code></li>
-            <li><code>Content-Type</code> header set to
-              <code>application/json</code>
-            </li>
-            <li>A body containing an <a href="#ActionStatus">
-                <code>ActionStatus</code></a> object serialized
-              in JSON</li>
-          </ul>
-	  </div>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-invokeaction-13">
+            <p>
+              If providing a Synchronous Action Response, a Web Thing MUST send
+              an HTTP response with:
+            </p>
+            <ul>
+              <li>Status code set to <code>200</code></li>
+              <li><code>Content-Type</code> header set to
+                <code>application/json</code>
+              </li>
+              <li>A body containing an <a href="#ActionStatus">
+                  <code>ActionStatus</code></a> object serialized
+                in JSON</li>
+            </ul>
+          </div>
           <pre class="example">
             HTTP/1.1 200 OK
             Content-Type: application/json
@@ -2491,32 +2481,31 @@
           </pre>
 
           <h6 id="async-action-response">Asynchronous Action Response</h6>
-	  <div class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-invokeaction-15">
-	  <p>
-            If providing an Asynchronous Action Response, a Web Thing MUST send 
-            an HTTP response containing the URL of an <code>ActionStatus</code>
-            resource, the
-            <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
-              scheme</a> [[RFC3986]] of which MUST resolve to <code>http</code>
-            or <code>https</code>. The response MUST have:
-	  </p>
-	  <ul>
-            <li>Status code set to <code>201</code></li>
-            <li><code>Content-Type</code> header set to
-              <code>application/json</code>
-            </li>
-            <li>
-              <code>Location</code> header set to the URL of the
-              <code>ActionStatus</code> resource
-            </li>
-            <li>A body containing an <a href="#ActionStatus">
-                <code>ActionStatus</code></a> object serialized
-              in JSON, with its <code>href</code> member set to the URL
-              of the <code>ActionStatus</code> resource
-            </li>
-          </ul>
-	  </div>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-invokeaction-15">
+            <p>
+              If providing an Asynchronous Action Response, a Web Thing MUST send
+              an HTTP response containing the URL of an <code>ActionStatus</code>
+              resource, the
+              <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                scheme</a> [[RFC3986]] of which MUST resolve to <code>http</code>
+              or <code>https</code>. The response MUST have:
+            </p>
+            <ul>
+              <li>Status code set to <code>201</code></li>
+              <li><code>Content-Type</code> header set to
+                <code>application/json</code>
+              </li>
+              <li>
+                <code>Location</code> header set to the URL of the
+                <code>ActionStatus</code> resource
+              </li>
+              <li>A body containing an <a href="#ActionStatus">
+                  <code>ActionStatus</code></a> object serialized
+                in JSON, with its <code>href</code> member set to the URL
+                of the <code>ActionStatus</code> resource
+              </li>
+            </ul>
+          </div>
           <pre class="example">
             HTTP/1.1 201 CREATED
             Content-Type: application/json
@@ -2535,69 +2524,64 @@
             A <code>queryaction</code> operation is used to query the current
             state of an ongoing action request.
           </p>
-	  <p><span class="rfc2119-assertion"
-            id="http-baseline-profile-protocol-binding-queryaction-1a">
-            A Web Thing which provides <a href="#async-action-response">
-              Asynchronous Action Response</a>s to an <code>invokeaction</code>
-            operation on an <code>Action</code> MUST also support
-            <code>queryaction</code> operations on
-            that same <code>Action</code>.</span>
-	  <span class="rfc2119-assertion"
-            id="http-baseline-profile-protocol-binding-queryaction-1b">
-            A Web Thing which only provides <a href="#sync-action-response">
-              Synchronous Action Response</a>s to an <code>invokeaction</code>
-            operation on an <code>Action</code> SHOULD NOT support
-            <code>queryaction</code> operations on that same
-            <code>Action</code>.</span>
-    </p>
-	  <p><span class="rfc2119-assertion"
-            id="http-baseline-profile-protocol-binding-queryaction-2">
-            The URL of an <code>ActionStatus</code> resource to be used in a 
-            <code>queryaction</code> operation MUST be obtained from the 
-            <code>Location</code> header of an <a href="#async-action-response">
-              Asynchronous Action Response</a>, or the <code>href</code> member of
-            the <code>ActionStatus</code> object in its body.</span>
-    </p>
-	  <div class="rfc2119-assertion"
-            id="http-baseline-profile-protocol-binding-queryaction-3">
-	  <p>
-            In order to query the status of an action request, a Consumer MUST 
-            send an HTTP request to a Web Thing with:
+          <p><span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-queryaction-1a">
+              A Web Thing which provides <a href="#async-action-response">
+                Asynchronous Action Response</a>s to an <code>invokeaction</code>
+              operation on an <code>Action</code> MUST also support
+              <code>queryaction</code> operations on
+              that same <code>Action</code>.</span>
+            <span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-queryaction-1b">
+              A Web Thing which only provides <a href="#sync-action-response">
+                Synchronous Action Response</a>s to an <code>invokeaction</code>
+              operation on an <code>Action</code> SHOULD NOT support
+              <code>queryaction</code> operations on that same
+              <code>Action</code>.</span>
           </p>
-	  <ul>
-            <li>Method set to <code>GET</code></li>
-            <li>
-              URL set to the URL of the <code>ActionStatus</code> resource
-            </li>
-            <li>
-              <code>Accept</code> header set to <code>application/json
+          <p><span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-queryaction-2">
+              The URL of an <code>ActionStatus</code> resource to be used in a
+              <code>queryaction</code> operation MUST be obtained from the
+              <code>Location</code> header of an <a href="#async-action-response">
+                Asynchronous Action Response</a>, or the <code>href</code> member of
+              the <code>ActionStatus</code> object in its body.</span>
+          </p>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-queryaction-3">
+            <p>
+              In order to query the status of an action request, a Consumer MUST
+              send an HTTP request to a Web Thing with:
+            </p>
+            <ul>
+              <li>Method set to <code>GET</code></li>
+              <li>
+                URL set to the URL of the <code>ActionStatus</code> resource
+              </li>
+              <li>
+                <code>Accept</code> header set to <code>application/json
               </code>
-            </li>
-          </ul>
-	  </div>
+              </li>
+            </ul>
+          </div>
           <pre class="example">
           GET /things/lamp/actions/fade/123e4567-e89b-12d3-a456-426655
           Host: mythingserver.com
           Accept: application/json
           </pre>
-	  <div class="rfc2119-assertion"
-            id="http-baseline-profile-protocol-binding-queryaction-5">
-	  <p>
-            If a Web Thing receives an HTTP request following the format
-            above and the Consumer has permission to query the corresponding
-            <code>ActionStatus</code> resource, then upon successfully reading
-            the status of the action request it MUST send an HTTP response
-            with:
-          </p>
-          <ul>
-            <li>Status code set to <code>200</code></li>
-            <li><code>Content-Type</code> header set to <code>application/json
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-queryaction-5">
+            <p>
+              If a Web Thing receives an HTTP request following the format
+              above and the Consumer has permission to query the corresponding
+              <code>ActionStatus</code> resource, then upon successfully reading
+              the status of the action request it MUST send an HTTP response
+              with:
+            </p>
+            <ul>
+              <li>Status code set to <code>200</code></li>
+              <li><code>Content-Type</code> header set to <code>application/json
               </code></li>
-            <li>A body containing an <code>ActionStatus</code> object
-              representing the current status of the action request, serialized
-              in JSON</li>
-          </ul>
-	  </div>
+              <li>A body containing an <code>ActionStatus</code> object
+                representing the current status of the action request, serialized
+                in JSON</li>
+            </ul>
+          </div>
           <pre class="example">
             HTTP/1.1 200 OK
             Content-Type: application/json
@@ -2606,19 +2590,17 @@
               "timeRequested": "2021-11-10T11:43:19.135Z"
             }
           </pre>
-	  <p>
-	  <span class="rfc2119-assertion"
-            id="http-baseline-profile-protocol-binding-queryaction-7a">
-            If the queried action failed to execute, then  
-            the <code>status</code> member of the <code>ActionStatus</code> object 
-            MUST be set to <code>"failed"</code>.</span>
-	  <span class="rfc2119-assertion"
-            id="http-baseline-profile-protocol-binding-queryaction-7b">
-            If the queried action failed to execute, then  
-	    the <code>error</code>
-            member MAY provide additional error information 
-            conforming to the Problem Details format [[RFC7807]].</span>
-    </p>
+          <p>
+            <span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-queryaction-7a">
+              If the queried action failed to execute, then
+              the <code>status</code> member of the <code>ActionStatus</code> object
+              MUST be set to <code>"failed"</code>.</span>
+            <span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-queryaction-7b">
+              If the queried action failed to execute, then
+              the <code>error</code>
+              member MAY provide additional error information
+              conforming to the Problem Details format [[RFC7807]].</span>
+          </p>
           <pre class="example">
             HTTP/1.1 200 OK
             Content-Type: application/json
@@ -2646,58 +2628,53 @@
             A <code>cancelaction</code> operation is used to cancel an ongoing
             <code>Action</code> request.
           </p>
-	  <p><span class="rfc2119-assertion"
-            id="http-baseline-profile-protocol-binding-cancelaction-1a">
-            A Web Thing which provides <a href="#async-action-response">
-              Asynchronous Action Response</a>s to an <code>invokeaction</code>
-            operation on an <code>Action</code> MAY also support
-            <code>cancelaction</code> operations on
-            that same <code>Action</code>.</span>
-	  <span class="rfc2119-assertion"
-            id="http-baseline-profile-protocol-binding-cancelaction-1b">
-            A Web Thing which only provides <a href="#sync-action-response">
-              Synchronous Action Response</a>s to an <code>invokeaction</code>
-            operation on an <code>Action</code> SHOULD NOT support
-            <code>cancelaction</code> operations on that same
-            <code>Action</code>.</span>
-    </p>
-	  <p><span class="rfc2119-assertion"
-            id="http-baseline-profile-protocol-binding-cancelaction-2">
-            The URL of an <code>ActionStatus</code> resource to be used in a 
-            <code>cancelaction</code> operation MUST be obtained from the 
-            <code>Location</code> header of an <a href="#async-action-response">
-              Asynchronous Action Response</a>, or the <code>href</code> member of
-            the <code>ActionStatus</code> object in its body.</span>
-    </p>
-	  <div class="rfc2119-assertion"
-            id="http-baseline-profile-protocol-binding-cancelaction-3">
-	  <p>
-            In order to cancel an action request, a Consumer MUST send an HTTP 
-            request to a Web Thing with:
-	  </p>
-	  <ul>
-            <li>Method set to <code>DELETE</code></li>
-            <li>
-              URL set to the URL of the <code>ActionStatus</code> resource
-            </li>
-          </ul>
-	  </div>
+          <p><span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-cancelaction-1a">
+              A Web Thing which provides <a href="#async-action-response">
+                Asynchronous Action Response</a>s to an <code>invokeaction</code>
+              operation on an <code>Action</code> MAY also support
+              <code>cancelaction</code> operations on
+              that same <code>Action</code>.</span>
+            <span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-cancelaction-1b">
+              A Web Thing which only provides <a href="#sync-action-response">
+                Synchronous Action Response</a>s to an <code>invokeaction</code>
+              operation on an <code>Action</code> SHOULD NOT support
+              <code>cancelaction</code> operations on that same
+              <code>Action</code>.</span>
+          </p>
+          <p><span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-cancelaction-2">
+              The URL of an <code>ActionStatus</code> resource to be used in a
+              <code>cancelaction</code> operation MUST be obtained from the
+              <code>Location</code> header of an <a href="#async-action-response">
+                Asynchronous Action Response</a>, or the <code>href</code> member of
+              the <code>ActionStatus</code> object in its body.</span>
+          </p>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-cancelaction-3">
+            <p>
+              In order to cancel an action request, a Consumer MUST send an HTTP
+              request to a Web Thing with:
+            </p>
+            <ul>
+              <li>Method set to <code>DELETE</code></li>
+              <li>
+                URL set to the URL of the <code>ActionStatus</code> resource
+              </li>
+            </ul>
+          </div>
           <pre class="example">
             DELETE /things/lamp/actions/fade/123e4567-e89b-12d3-a456-426655 HTTP/1.1
             Host: mythingserver.com
           </pre>
-	  <div class="rfc2119-assertion"
-            id="http-baseline-profile-protocol-binding-cancelaction-5">
-	  <p>
-            If a Web Thing receives an HTTP request following the format
-            above and the Consumer has permission to cancel the corresponding
-            <code>Action</code> request, then upon successfully cancelling
-            <code>Action</code> it MUST send an HTTP response with:
-          </p>
-          <ul>
-            <li>Status code set to <code>204</code></li>
-          </ul>
-	  </div>
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-cancelaction-5">
+            <p>
+              If a Web Thing receives an HTTP request following the format
+              above and the Consumer has permission to cancel the corresponding
+              <code>Action</code> request, then upon successfully cancelling
+              <code>Action</code> it MUST send an HTTP response with:
+            </p>
+            <ul>
+              <li>Status code set to <code>204</code></li>
+            </ul>
+          </div>
           <pre class="example">
             HTTP/1.1 204 No Content
           </pre>
@@ -2705,78 +2682,73 @@
 
         <section id="queryallactions">
           <h5><code>queryallactions</code></h5>
-	  <div class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-queryallactions-1">
-	  <p>
-            The URL of an <code>Actions</code> resource to be used when
-            querying the status of all ongoing action requests MUST be obtained
-            from a Thing Description by locating a
-            <a href="https://www.w3.org/TR/wot-thing-description/#form">
-              <code>Form</code></a> inside the top level
-            <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json">
-              <code>forms</code></a> member
-            for which:
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-queryallactions-1">
+            <p>
+              The URL of an <code>Actions</code> resource to be used when
+              querying the status of all ongoing action requests MUST be obtained
+              from a Thing Description by locating a
+              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+                <code>Form</code></a> inside the top level
+              <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json">
+                <code>forms</code></a> member
+              for which:
+            </p>
+            <ul>
+              <li>
+                Its <code>op</code> member contains the value
+                <code>queryallactions</code>
+              </li>
+              <li>
+                After being resolved against a base URL where applicable, the
+                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                  scheme</a> [[RFC3986]] of the value of its <code>href</code>
+                member is <code>http</code> or <code>https</code>
+              </li>
+            </ul>
+          </div>
+          <p><span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-queryallactions-3">
+              The resolved value of the <code>href</code> member MUST then be used
+              as the URL of the <code>Actions</code> resource.</span>
           </p>
-	  <ul>
-            <li>
-              Its <code>op</code> member contains the value
-              <code>queryallactions</code>
-            </li>
-            <li>
-              After being resolved against a base URL where applicable, the
-              <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
-                scheme</a> [[RFC3986]] of the value of its <code>href</code>
-              member is <code>http</code> or <code>https</code>
-            </li>
-          </ul>
-	  </div>
-	  <p><span class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-queryallactions-3">
-            The resolved value of the <code>href</code> member MUST then be used
-            as the URL of the <code>Actions</code> resource.</span>
-    </p>
-	  <div class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-queryallactions-4">
-		  <p>
-            In order to query the status of all ongoing action requests, a
-            Consumer MUST send an HTTP request to a Web Thing with:
-	  </p>
-	  <ul>
-            <li>Method set to <code>GET</code></li>
-            <li>URL set to the URL of the <code>Actions</code> resource
-            </li>
-            <li><code>Accept</code> header set to <code>application/json
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-queryallactions-4">
+            <p>
+              In order to query the status of all ongoing action requests, a
+              Consumer MUST send an HTTP request to a Web Thing with:
+            </p>
+            <ul>
+              <li>Method set to <code>GET</code></li>
+              <li>URL set to the URL of the <code>Actions</code> resource
+              </li>
+              <li><code>Accept</code> header set to <code>application/json
               </code></li>
-          </ul>
+            </ul>
           </div>
           <pre class="example">
           GET /things/lamp/actions HTTP/1.1
           Host: mythingserver.com
           Accept: application/json
           </pre>
-	  <div class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-queryallactions-6a">
-	  <p>
-            If a Web Thing receives an HTTP request following the format
-            above, then upon successfully retreiving the status of all ongoing
-            action requests to which the Consumer has permission to access, it
-            MUST send an HTTP response with:
-          </p>
-          <ul>
-            <li>Status code set to <code>200</code></li>
-            <li><code>Content-Type</code> header set to <code>application/json
+          <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-queryallactions-6a">
+            <p>
+              If a Web Thing receives an HTTP request following the format
+              above, then upon successfully retreiving the status of all ongoing
+              action requests to which the Consumer has permission to access, it
+              MUST send an HTTP response with:
+            </p>
+            <ul>
+              <li>Status code set to <code>200</code></li>
+              <li><code>Content-Type</code> header set to <code>application/json
               </code></li>
-            <li>A body containing an object, keyed by <code>Action</code> name,
-              with the value of each object member being an array of 
-              <a href="#ActionStatus"><code>ActionStatus</code></a> objects 
-              representing the action requests, serialized in JSON. 
-            </li>
-          </ul>
+              <li>A body containing an object, keyed by <code>Action</code> name,
+                with the value of each object member being an array of
+                <a href="#ActionStatus"><code>ActionStatus</code></a> objects
+                representing the action requests, serialized in JSON.
+              </li>
+            </ul>
           </div>
-	  <p><span class="rfc2119-assertion" 
-            id="http-baseline-profile-protocol-binding-queryallactions-6b">
-	      Each array in the result object
-              MUST be sorted in reverse chronological order such that the 
+          <p><span class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-queryallactions-6b">
+              Each array in the result object
+              MUST be sorted in reverse chronological order such that the
               most recent action request appears first.</span>
           <pre class="example">
           HTTP/1.1 200 OK
@@ -2830,37 +2802,37 @@
         <h4 id="error-responses">Error Responses</h4>
         <p>
           <span class="rfc2119-assertion" id="profile-5-2-4x-thing-protocol-binding-error-responses-1a">
-          If any of the operations defined above are unsuccessful then
-          the Web Thing MUST send an HTTP response with an HTTP error code which
-          describes the reason for the failure.</span>
-	</p>
-        <div class="rfc2119-assertion" id="profile-5-2-4x-thing-protocol-binding-error-responses-1b">
-	<p>
-	  It is RECOMMENDED that error
-          responses use one of the following HTTP error codes:
+            If any of the operations defined above are unsuccessful then
+            the Web Thing MUST send an HTTP response with an HTTP error code which
+            describes the reason for the failure.</span>
         </p>
-        <ul>
-          <li><code>400 Bad Request</code></li>
-          <li><code>401 Unauthorized</code></li>
-          <li><code>403 Forbidden</code></li>
-          <li><code>404 Not Found</code></li>
-          <li><code>500 Internal Server Error</code></li>
-        </ul>
-          </div>
+        <div class="rfc2119-assertion" id="profile-5-2-4x-thing-protocol-binding-error-responses-1b">
+          <p>
+            It is RECOMMENDED that error
+            responses use one of the following HTTP error codes:
+          </p>
+          <ul>
+            <li><code>400 Bad Request</code></li>
+            <li><code>401 Unauthorized</code></li>
+            <li><code>403 Forbidden</code></li>
+            <li><code>404 Not Found</code></li>
+            <li><code>500 Internal Server Error</code></li>
+          </ul>
+        </div>
         <p>
-          <span class="rfc2119-assertion" id="profile-5-2-4x-thing-protocol-binding-error-responses-2">	      
-	      A Web Thing MUST NOT issue any 3xx status codes.</span>
-          <span class="rfc2119-assertion" id="profile-5-2-4x-thing-protocol-binding-error-responses-3">	      
-	      A Consumer MAY treat all 3xx codes as errors that do not change the status or behavior 
-	      of the consumer.</span> 
-	</p>
+          <span class="rfc2119-assertion" id="profile-5-2-4x-thing-protocol-binding-error-responses-2">
+            A Web Thing MUST NOT issue any 3xx status codes.</span>
+          <span class="rfc2119-assertion" id="profile-5-2-4x-thing-protocol-binding-error-responses-3">
+            A Consumer MAY treat all 3xx codes as errors that do not change the status or behavior
+            of the consumer.</span>
+        </p>
         <p>
           <span class="rfc2119-assertion" id="profile-5-2-4x-thing-protocol-binding-error-responses-4">
-          Web Things MAY respond with other valid HTTP error codes
-          (e.g. <code>418 I'm a teapot</code>).</span>
+            Web Things MAY respond with other valid HTTP error codes
+            (e.g. <code>418 I'm a teapot</code>).</span>
           <span class="rfc2119-assertion" id="profile-5-2-4x-thing-protocol-binding-error-responses-3b">
-          Consumers MAY interpret other valid HTTP error codes as a generic <code>4xx</code> or <code>5xx</code>
-          error with no special defined behaviour.</span>
+            Consumers MAY interpret other valid HTTP error codes as a generic <code>4xx</code> or <code>5xx</code>
+            error with no special defined behaviour.</span>
         </p>
         <p class="ednote">
           <!-- <span id="profile-5-2-4-thing-protocol-binding-error-responses-6"> -->
@@ -2869,27 +2841,25 @@
           redirect type response.
           <!-- </span> -->
         <p class="ednote">
-           It turns out 3xx redirection codes are used as part of some OAuth2 flows, so it may be 
-           in appropriate to disallow them generally.  See the "Security Bootstrapping" section of 
-           WoT Discovery.
+          It turns out 3xx redirection codes are used as part of some OAuth2 flows, so it may be
+          in appropriate to disallow them generally. See the "Security Bootstrapping" section of
+          WoT Discovery.
         </p>
         </p>
         <p>
           <span class="rfc2119-assertion" id="profile-5-2-4x-thing-protocol-binding-error-responses-7">
-          If an HTTP error response contains a body, the content of that body
-          MUST conform with with the Problem Details format [[RFC7807]].</span>
+            If an HTTP error response contains a body, the content of that body
+            MUST conform with with the Problem Details format [[RFC7807]].</span>
         </p>
       </section>
 
       <section id="security">
         <h4 id="security">Transport security</h4>
-      </p>
-      <p class="ednote">
-        Consider mandating HTTPs, at least for things that are used outside of a closed network.
-        Some other standards, such as Echonet use HTTPS only.
-      </p>
-  
-      
+        </p>
+        <p class="ednote">
+          Consider mandating HTTPs, at least for things that are used outside of a closed network.
+          Some other standards, such as Echonet use HTTPS only.
+        </p>
       </section>
 
     </section>
@@ -2897,85 +2867,85 @@
     <!--  Security -->
     <section>
       <h2 id="http-baseline-profile-security">Security</h3>
-      <p class="ednote" title="Restructure Assertion">
-      This assertion has two keywords, one optional and one mandatory, and needs to be broken into two
-      statements. The question is how to do it without repeating the list.
-    </p>
-    <div class="rfc2119-assertion" id="http-baseline-profile-security-1-x">
-      <p>
-        Below is a list of <a href="https://w3c.github.io/wot-thing-description/#sec-security-vocabulary-definition">
-          security schemes</a> [[wot-thing-description]] which conformant Web
-        Things MAY use and conformant Consumers MUST support:
-      </p>
-      <ul>
-        <li>
-          <a href="https://w3c.github.io/wot-thing-description/#nosecurityscheme">
-            <code>NoSecurityScheme</code>
-          </a>
-        </li>
-        <li>
-          <a href="https://w3c.github.io/wot-thing-description/#basicsecurityscheme">
-            <code>BasicSecurityScheme</code>
-          </a>
-        </li>
-        <li>
-          <a href="https://w3c.github.io/wot-thing-description/#digestsecurityscheme">
-            <code>DigestSecurityScheme</code>
-          </a>
-        </li>
-        <li>
-          <a href="https://w3c.github.io/wot-thing-description/#bearersecurityscheme">
-            <code>BearerSecurityScheme</code>
-          </a>
-        </li>
-        <li>
-          <a href="https://w3c.github.io/wot-thing-description/#oauth2securityscheme">
-            <code>OAuth2SecurityScheme</code>
-          </a>
-        </li>
-      </ul>
-      </div>
-      <p class="ednote">
-        The list of security schemes to include in the HTTP Baseline Profile is
-        still <a href="https://github.com/w3c/wot-profile/issues/6">under 
-        discussion</a>.
-      </p>
-      <p><span class="rfc2119-assertion" id="http-baseline-profile-security-2-x">
-        A Thing MAY implement multiple security schemes.</span>
-      </p>
-      <p><span class="rfc2119-assertion" id="http-baseline-profile-security-3a-x">
-        Security schemes MUST be applied using the top level <code>security</code>
-        member of a 
-        <a href="https://w3c.github.io/wot-thing-description/#thing">Thing</a>.</span>
-      </p>
-      <p><span class="rfc2119-assertion" id="http-baseline-profile-security-3b-x">
-        Security schemes 
-        MUST NOT be applied to individual
-        <a href="https://w3c.github.io/wot-thing-description/#form"></a><code>
+        <p class="ednote" title="Restructure Assertion">
+          This assertion has two keywords, one optional and one mandatory, and needs to be broken into two
+          statements. The question is how to do it without repeating the list.
+        </p>
+        <div class="rfc2119-assertion" id="http-baseline-profile-security-1-x">
+          <p>
+            Below is a list of <a
+              href="https://w3c.github.io/wot-thing-description/#sec-security-vocabulary-definition">
+              security schemes</a> [[wot-thing-description]] which conformant Web
+            Things MAY use and conformant Consumers MUST support:
+          </p>
+          <ul>
+            <li>
+              <a href="https://w3c.github.io/wot-thing-description/#nosecurityscheme">
+                <code>NoSecurityScheme</code>
+              </a>
+            </li>
+            <li>
+              <a href="https://w3c.github.io/wot-thing-description/#basicsecurityscheme">
+                <code>BasicSecurityScheme</code>
+              </a>
+            </li>
+            <li>
+              <a href="https://w3c.github.io/wot-thing-description/#digestsecurityscheme">
+                <code>DigestSecurityScheme</code>
+              </a>
+            </li>
+            <li>
+              <a href="https://w3c.github.io/wot-thing-description/#bearersecurityscheme">
+                <code>BearerSecurityScheme</code>
+              </a>
+            </li>
+            <li>
+              <a href="https://w3c.github.io/wot-thing-description/#oauth2securityscheme">
+                <code>OAuth2SecurityScheme</code>
+              </a>
+            </li>
+          </ul>
+        </div>
+        <p class="ednote">
+          The list of security schemes to include in the HTTP Baseline Profile is
+          still <a href="https://github.com/w3c/wot-profile/issues/6">under
+            discussion</a>.
+        </p>
+        <p><span class="rfc2119-assertion" id="http-baseline-profile-security-2-x">
+            A Thing MAY implement multiple security schemes.</span>
+        </p>
+        <p><span class="rfc2119-assertion" id="http-baseline-profile-security-3a-x">
+            Security schemes MUST be applied using the top level <code>security</code>
+            member of a
+            <a href="https://w3c.github.io/wot-thing-description/#thing">Thing</a>.</span>
+        </p>
+        <p><span class="rfc2119-assertion" id="http-baseline-profile-security-3b-x">
+            Security schemes
+            MUST NOT be applied to individual
+            <a href="https://w3c.github.io/wot-thing-description/#form"></a><code>
         Form</code>s.</span>
-      </p>
-      <p class="note">
-        Please see <a href="https://w3c.github.io/wot-security-best-practices/">
-        WoT Security Best Practices</a> for implementation advice.
-      </p>
+        </p>
+        <p class="note">
+          Please see <a href="https://w3c.github.io/wot-security-best-practices/">
+            WoT Security Best Practices</a> for implementation advice.
+        </p>
     </section>
 
     <!-- Discovery -->
     <section>
       <h2 id="http-baseline-profile-discovery">Discovery</h2>
       <p class="rfc2119-assertion" id="http-baseline-profile-discovery-1">
-        In order to conform with the HTTP Baseline Profile, a Web Thing's Thing 
-        Description [[wot-thing-description]] MUST be retrievable from a 
+        In order to conform with the HTTP Baseline Profile, a Web Thing's Thing
+        Description [[wot-thing-description]] MUST be retrievable from a
         <a href="https://w3c.github.io/wot-architecture/#dfn-wot-thing-description-server">
-        Thing Description Server</a> [[wot-architecture11]] using an HTTP 
-        [[HTTP11]] URL provided by a 
+          Thing Description Server</a> [[wot-architecture11]] using an HTTP
+        [[HTTP11]] URL provided by a
         <a href="https://w3c.github.io/wot-discovery/#introduction-mech">
-        Direct Introduction Mechanism</a> [[wot-discovery]].
+          Direct Introduction Mechanism</a> [[wot-discovery]].
       </p>
     </section>
   </section>
   </section>
-
 
   <section id="sec-http-sse-profile">
     <h1>HTTP SSE Profile</h1>
@@ -2993,12 +2963,12 @@
     <section id="http-sse-profile-identifier">
       <h2>Identifier</h2>
       <p><span class="rfc2119-assertion" id="http-sse-profile-1">
-        In order to denote that a given
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
-        conforms to the HTTP SSE Profile, its Thing Description MUST have a
-        <a href="https://w3c.github.io/wot-thing-description/#thing">
-          <code>profile</code></a> member [[wot-thing-description]] with a value
-        of <code>https://www.w3.org/2022/wot/profile/http-sse/v1</code>.</span>
+          In order to denote that a given
+          <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+          conforms to the HTTP SSE Profile, its Thing Description MUST have a
+          <a href="https://w3c.github.io/wot-thing-description/#thing">
+            <code>profile</code></a> member [[wot-thing-description]] with a value
+          of <code>https://www.w3.org/2022/wot/profile/http-sse/v1</code>.</span>
       </p>
     </section>
     <section id="http-sse-profile-protocol-binding">
@@ -3015,8 +2985,8 @@
           A Consumer or Web Thing conforming to the HTTP SSE Profile
           MUST implement this protocol binding.</span>
       </p>
-      
-            <p>
+
+      <p>
         The examples provided throughout this section describe how a Consumer
         would communicate with a Web Thing which produces the following Thing
         Description:
@@ -3119,27 +3089,26 @@
 
         <section id="observeproperty">
           <h5><code>observeproperty</code></h5>
-          <div class="rfc2119-assertion"
-            id="http-sse-profile-protocol-binding-observeproperty-1">
+          <div class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeproperty-1">
             <p>
               The URL of a <code>Property</code> resource to be used when
-              observing the value of a property MUST be obtained from a Thing 
+              observing the value of a property MUST be obtained from a Thing
               Description by locating a
               <a href="https://www.w3.org/TR/wot-thing-description/#form">
-              <code>Form</code></a> inside the corresponding
+                <code>Form</code></a> inside the corresponding
               <a href="https://www.w3.org/TR/wot-thing-description/#propertyaffordance">
-              <code>PropertyAffordance</code></a>
+                <code>PropertyAffordance</code></a>
               for which:
             </p>
             <ul>
               <li>
-                Its <code>op</code> member contains the value 
+                Its <code>op</code> member contains the value
                 <code>observeproperty</code>
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
                 <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
-                scheme</a> [[RFC3986]] of the value of its <code>href</code>
+                  scheme</a> [[RFC3986]] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
               <li>Its <code>subprotocol</code> member has a value of
@@ -3148,17 +3117,15 @@
             </ul>
           </div>
           <p>
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeproperty-2">
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeproperty-2">
               The resolved value of the <code>href</code> member MUST then be
               used as the URL of the <code>Property</code> resource.</span>
           </p>
           <p>
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeproperty-3">
-              In order to observe a property, a Consumer MUST follow the 
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeproperty-3">
+              In order to observe a property, a Consumer MUST follow the
               Server-Sent Events [[EVENTSOURCE]] specification to open a
-              connection with the Web Thing at the URL of the 
+              connection with the Web Thing at the URL of the
               <code>Property</code> resource.</span>
           </p>
           <p>
@@ -3182,34 +3149,33 @@
             Connection: keep-alive
           </pre>
           <p class="note" title="Opening a connection using JavaScript">
-            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed 
+            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed
             in a runtime which exposes the
             <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface">
-            <code>EventSource</code></a> interface, a Server-Sent Events 
+              <code>EventSource</code></a> interface, a Server-Sent Events
             connection can be initiated using the <code>EventSource</code>
             constructor.
-            <pre class="example">
+          <pre class="example">
               const levelSource = new EventSource('/things/lamp/properties/level');
             </pre>
           </p>
           <p>
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeproperty-4">
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeproperty-4">
               If a Web Thing receives an HTTP request following the format
-              above and the Consumer has permission to observe the 
-              corresponding property, then it MUST follow the Server-Sent Events 
-              [[EVENTSOURCE]] specification to maintain an open connection with 
-              the Consumer and push a property value to the Consumer each time 
+              above and the Consumer has permission to observe the
+              corresponding property, then it MUST follow the Server-Sent Events
+              [[EVENTSOURCE]] specification to maintain an open connection with
+              the Consumer and push a property value to the Consumer each time
               the value of the specified property changes.</span>
           </p>
           <p>
-            This involves the Web Thing initially sending an HTTP 
+            This involves the Web Thing initially sending an HTTP
             response to the Consumer with:
           </p>
           <ul>
             <li>Status code set to <code>200</code></li>
             <li>
-              <code>Content-Type</code> header set to 
+              <code>Content-Type</code> header set to
               <code>text/event-stream</code>
             </li>
           </ul>
@@ -3218,26 +3184,22 @@
             Content-Type: text/event-stream
           </pre>
           <p>
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeproperty-5a">
-              Whenever the value of the specified property changes while the Web 
-              Thing has an open connection with a Consumer, the Web Thing MUST 
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeproperty-5a">
+              Whenever the value of the specified property changes while the Web
+              Thing has an open connection with a Consumer, the Web Thing MUST
               send a property value to the Consumer using the event stream
               format in the Server-Sent Events [[EVENTSOURCE]] specification.</span>
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeproperty-5b">
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeproperty-5b">
               For each message sent, the Web Thing MUST set the
               <code>event</code> field to the name of the
               <code>PropertyAffordance</code> and populate the <code>data</code>
               field with the property value, serialized in JSON and following
               the data schema specified in the <code>PropertyAffordance</code>.</span>
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeproperty-5c">
-              The <code>id</code> field SHOULD be set to a unique 
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeproperty-5c">
+              The <code>id</code> field SHOULD be set to a unique
               identifier for the property change, for use when re-establishing a
               dropped connection (see below).</span>
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeproperty-5d">
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeproperty-5d">
               It is RECOMMENDED that the
               identifier is a timestamp representing the time at which the
               property changed, in the &quotdate-time&quot format specified by
@@ -3249,15 +3211,13 @@
             id: 2021-11-17T15:33:20.827Z\n\n
           </pre>
           <p>
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeproperty-6a">
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeproperty-6a">
               If the connection between the Consumer and Web Thing drops
-              (except as a result of the <code>unobserve</code> operation 
-              defined below), the Consumer MUST re-establish the connection 
+              (except as a result of the <code>unobserve</code> operation
+              defined below), the Consumer MUST re-establish the connection
               following the steps outlined in the Server-Sent Events
-              specification [[EVENTSOURCE]].</span> 
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeproperty-6b">
+              specification [[EVENTSOURCE]].</span>
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeproperty-6b">
               Once the connection is
               re-established the Web Thing SHOULD, if possible, send any missed
               property changes which occured since the last change specified by
@@ -3268,21 +3228,20 @@
         <section id="unobserveproperty">
           <h5><code>unobserveproperty</code></h5>
           <p>
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-unobserveproperty-1">
-              In order to stop observing a property, a Consumer MUST terminate 
-              the corresponding Server-Sent Events connection with the Web Thing 
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-unobserveproperty-1">
+              In order to stop observing a property, a Consumer MUST terminate
+              the corresponding Server-Sent Events connection with the Web Thing
               as specified in the Server-Sent Events specification
               [[EVENTSOURCE]].</span>
           </p>
           <p class="note" title="Terminating a connection using JavaScript">
-            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed 
+            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed
             in a runtime which exposes the
             <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface">
-            <code>EventSource</code></a> interface, a Server-Sent Events 
-            connection can be terminated using the <code>close()</code> method 
+              <code>EventSource</code></a> interface, a Server-Sent Events
+            connection can be terminated using the <code>close()</code> method
             on an <code>EventSource</code> [[EVENTSOURCE]] object.
-            <pre class="example">
+          <pre class="example">
               levelSource.close();
             </pre>
           </p>
@@ -3290,26 +3249,25 @@
 
         <section id="observeallproperties">
           <h5><code>observeallproperties</code></h5>
-          <div class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-observeallproperties-1">
+          <div class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeallproperties-1">
             <p>
-                The URL of a properties resource to be used when observing
-                changes to all properties of a Web Thing MUST be obtained from a
-                Thing Description by locating a 
-                <a href="https://www.w3.org/TR/wot-thing-description/#form">
-                <code>Form</code></a> inside the top level 
-                <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json"><code>forms</code></a>
-                member of a Thing Description for which:
+              The URL of a properties resource to be used when observing
+              changes to all properties of a Web Thing MUST be obtained from a
+              Thing Description by locating a
+              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+                <code>Form</code></a> inside the top level
+              <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json"><code>forms</code></a>
+              member of a Thing Description for which:
             </p>
             <ul>
               <li>
-                Its <code>op</code> member contains the value 
+                Its <code>op</code> member contains the value
                 <code>observeallproperties</code>
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
                 <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
-                scheme</a> [[RFC3986]] of the value of its <code>href</code>
+                  scheme</a> [[RFC3986]] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
               <li>Its <code>subprotocol</code> member has a value of
@@ -3318,14 +3276,12 @@
             </ul>
           </div>
           <p>
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeallproperties-2">
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeallproperties-2">
               The resolved value of the <code>href</code> member MUST then be
               used as the URL of the properties resource.</span>
           </p>
           <p>
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeallproperties-3">
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeallproperties-3">
               In order to observe changes to all properties of a Web Thing, a
               Consumer MUST follow the Server-Sent Events [[EVENTSOURCE]]
               specification to open a connection with the Web Thing at the URL
@@ -3352,33 +3308,32 @@
             Connection: keep-alive
           </pre>
           <p class="note" title="Opening a connection using JavaScript">
-            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed 
+            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed
             in a runtime which exposes the
             <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface">
-            <code>EventSource</code></a> interface, a Server-Sent Events 
+              <code>EventSource</code></a> interface, a Server-Sent Events
             connection can be initiated using the <code>EventSource</code>
             constructor.
-            <pre class="example">
+          <pre class="example">
               const lampPropertiesSource = new EventSource('/things/lamp/properties');
             </pre>
           </p>
           <p>
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeallproperties-4">
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeallproperties-4">
               If a Web Thing receives an HTTP request following the format
-              above then it MUST follow the Server-Sent Events 
-              [[EVENTSOURCE]] specification to maintain an open connection with 
-              the Consumer and push new property values to the Consumer for all 
+              above then it MUST follow the Server-Sent Events
+              [[EVENTSOURCE]] specification to maintain an open connection with
+              the Consumer and push new property values to the Consumer for all
               properties for which it has permission to observe.</span>
           </p>
           <p>
-            This involves the Web Thing initially sending an HTTP 
+            This involves the Web Thing initially sending an HTTP
             response to the Consumer with:
           </p>
           <ul>
             <li>Status code set to <code>200</code></li>
             <li>
-              <code>Content-Type</code> header set to 
+              <code>Content-Type</code> header set to
               <code>text/event-stream</code>
             </li>
           </ul>
@@ -3387,30 +3342,25 @@
             Content-Type: text/event-stream
           </pre>
           <p>
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeallproperties-5a">
-              Whenever a property changes while the Web Thing has an open 
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeallproperties-5a">
+              Whenever a property changes while the Web Thing has an open
               connection with a Consumer, the Web Thing MUST send the new
               property value to the Consumer using the event stream format in
-              the Server-Sent Events [[EVENTSOURCE]] specification.</span> 
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeallproperties-5b">
+              the Server-Sent Events [[EVENTSOURCE]] specification.</span>
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeallproperties-5b">
               For each message sent, the Web Thing MUST set the <code>event</code> field
               to the name of the <code>PropertyAffordance</code> and populate
-              the <code>data</code> field with the new property value.</span> 
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeallproperties-5c">
+              the <code>data</code> field with the new property value.</span>
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeallproperties-5c">
               The property data MUST follow the data schema specified in the
               <code>PropertyAffordance</code> and MUST be serialized in JSON.</span>
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeallproperties-5d">
-              The <code>id</code> field SHOULD be set to a unique identifier for 
-              the event, for use when re-establishing a dropped connection (see 
-              below).</span> 
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeallproperties-5e">
-              It is RECOMMENDED that the identifier is a timestamp 
-              representing the time at which the property changed, in the 
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeallproperties-5d">
+              The <code>id</code> field SHOULD be set to a unique identifier for
+              the event, for use when re-establishing a dropped connection (see
+              below).</span>
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeallproperties-5e">
+              It is RECOMMENDED that the identifier is a timestamp
+              representing the time at which the property changed, in the
               &quot;date-time&quot; format specified by [[RFC3339]].</span>
           </p>
           <pre class="example">
@@ -3419,17 +3369,15 @@
             id: 2021-11-17T15:33:20.827Z\n\n
           </pre>
           <p>
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeallproperties-6a">
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeallproperties-6a">
               If the connection between the Consumer and Web Thing drops
               (except as a result of the <code>unobserveallproperties</code>
               operation defined below), the Consumer MUST re-establish the
               connection following the steps outlined in the Server-Sent Events
-              specification [[EVENTSOURCE]].</span> 
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-observeallproperties-6b">
+              specification [[EVENTSOURCE]].</span>
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-observeallproperties-6b">
               Once the connection is
-              re-established the Web Thing SHOULD, if possible, send any missed 
+              re-established the Web Thing SHOULD, if possible, send any missed
               property changes which occured since the last change specified by
               the Consumer in a <code>Last-Event-ID</code> header.</span>
           </p>
@@ -3438,21 +3386,20 @@
         <section id="unobserveallproperties">
           <h5><code>unobserveallproperties</code></h5>
           <p>
-            <span class="rfc2119-assertion" 
-              id="http-sse-profile-protocol-binding-unobserveallproperties-1">
-              In order to unobserve all properties, a Consumer MUST terminate 
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-unobserveallproperties-1">
+              In order to unobserve all properties, a Consumer MUST terminate
               the corresponding Server-Sent Events connection with the
               properties endpoint of the Web Thing, following the steps
               specified in the Server-Sent Events specification [[EVENTSOURCE]].</span>
           </p>
           <p class="note" title="Terminating a connection using JavaScript">
-            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed 
+            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed
             in a runtime which exposes the
             <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface">
-            <code>EventSource</code></a> interface, a Server-Sent Events 
-            connection can be terminated using the <code>close()</code> method 
+              <code>EventSource</code></a> interface, a Server-Sent Events
+            connection can be terminated using the <code>close()</code> method
             on an <code>EventSource</code> [[EVENTSOURCE]] object.
-            <pre class="example">
+          <pre class="example">
               lampPropertiesSource.close();
             </pre>
           </p>
@@ -3476,45 +3423,42 @@
         </p>
         <section id="http-sse-profile-protocol-binding-subscribeevent">
           <h5><code>subscribeevent</code></h5>
-	  <div class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeevent-1">
-		  <p>
-            The URL of an <code>Event</code> resource to be used when 
-            subscribing to an event MUST be obtained from a Thing Description 
-            by locating a 
-            <a href="https://www.w3.org/TR/wot-thing-description/#form">
-              <code>Form</code></a> inside the corresponding
-            <a href="https://www.w3.org/TR/wot-thing-description/#eventaffordance">
-            <code>EventAffordance</code></a> for which:
-	  </p>
-          <ul>
-            <li>
-              After defaults have been applied, its <code>op</code> member
-              contains the value <code>subscribeevent</code>
-            </li>
-            <li>
-              After being resolved against a base URL where applicable, the
-              <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
-                scheme</a> [[RFC3986]] of the value of its <code>href</code>
-              member is <code>http</code> or <code>https</code>
-            </li>
-            <li>Its <code>subprotocol</code> member has a value of
-              <code>sse</code>
-            </li>
-          </ul>
-	  </div>
-	  <p><span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeevent-3">
-            The resolved value of the <code>href</code> member MUST then be used
-            as the URL of the <code>Event</code> resource.</span>
-    </p>
-	  <p><span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeevent-4">
-            In order to subscribe to an event, a Consumer MUST follow the 
-            Server-Sent Events [[EVENTSOURCE]] specification to open a
-            connection with the Web Thing at the URL of the <code>Event</code>
-            resource.</span>
-    </p>
+          <div class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeevent-1">
+            <p>
+              The URL of an <code>Event</code> resource to be used when
+              subscribing to an event MUST be obtained from a Thing Description
+              by locating a
+              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+                <code>Form</code></a> inside the corresponding
+              <a href="https://www.w3.org/TR/wot-thing-description/#eventaffordance">
+                <code>EventAffordance</code></a> for which:
+            </p>
+            <ul>
+              <li>
+                After defaults have been applied, its <code>op</code> member
+                contains the value <code>subscribeevent</code>
+              </li>
+              <li>
+                After being resolved against a base URL where applicable, the
+                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                  scheme</a> [[RFC3986]] of the value of its <code>href</code>
+                member is <code>http</code> or <code>https</code>
+              </li>
+              <li>Its <code>subprotocol</code> member has a value of
+                <code>sse</code>
+              </li>
+            </ul>
+          </div>
+          <p><span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeevent-3">
+              The resolved value of the <code>href</code> member MUST then be used
+              as the URL of the <code>Event</code> resource.</span>
+          </p>
+          <p><span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeevent-4">
+              In order to subscribe to an event, a Consumer MUST follow the
+              Server-Sent Events [[EVENTSOURCE]] specification to open a
+              connection with the Web Thing at the URL of the <code>Event</code>
+              resource.</span>
+          </p>
           <p>
             This involves the Consumer sending an HTTP request to
             the Web Thing with:
@@ -3546,15 +3490,14 @@
               const overheatedEventSource = new EventSource('/things/lamp/events/overheated');
             </pre>
           </p>
-	  <p><span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeevent-5">
-            If a Web Thing receives an HTTP request following the format
-            above and the Consumer has permission to subscribe to the
-            corresponding event, then it MUST follow the Server-Sent Events
-            [[EVENTSOURCE]] specification to maintain an open connection with
-            the Consumer and push event data to the Consumer as events of the
-            specified type are emitted.</span>
-    </p>
+          <p><span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeevent-5">
+              If a Web Thing receives an HTTP request following the format
+              above and the Consumer has permission to subscribe to the
+              corresponding event, then it MUST follow the Server-Sent Events
+              [[EVENTSOURCE]] specification to maintain an open connection with
+              the Consumer and push event data to the Consumer as events of the
+              specified type are emitted.</span>
+          </p>
           <p>
             This involves the Web Thing initially sending an HTTP
             response to the Consumer with:
@@ -3570,119 +3513,108 @@
           HTTP/1.1 200 OK
           Content-Type: text/event-stream
           </pre>
-	  <p><span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeevent-6a">
-            Whenever an event of the specified type occurs while the Web Thing 
-            has an open connection with a Consumer, the Web Thing MUST 
-            send event data to the Consumer using the event stream format in the 
-            Server-Sent Events [[EVENTSOURCE]] specification.</span>
-	  <span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeevent-6b">
-	    For each message 
-            sent, the Web Thing MUST set the <code>event</code> field to the 
-            name of the <code>EventAffordance</code> and populate the 
-            <code>data</code> field with event data, if any.</span>
-	  <span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeevent-6c">
-	    The 
-            event data MUST follow the data schema specified in the
-            <code>EventAffordance</code>
-	    and be serialized in JSON.</span>
-	  <span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeevent-6d">
-            The <code>id</code> field SHOULD be set to a unique identifier for 
-            the event, for use when re-establishing a dropped connection (see 
-            below).</span>
-    <span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeevent-6e">
-            It is RECOMMENDED that the identifier is a timestamp 
-            representing the time at which the event ocurred, in the 
-            &quot;date-time&quot; format specified by [[RFC3339]].</span>
+          <p><span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeevent-6a">
+              Whenever an event of the specified type occurs while the Web Thing
+              has an open connection with a Consumer, the Web Thing MUST
+              send event data to the Consumer using the event stream format in the
+              Server-Sent Events [[EVENTSOURCE]] specification.</span>
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeevent-6b">
+              For each message
+              sent, the Web Thing MUST set the <code>event</code> field to the
+              name of the <code>EventAffordance</code> and populate the
+              <code>data</code> field with event data, if any.</span>
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeevent-6c">
+              The
+              event data MUST follow the data schema specified in the
+              <code>EventAffordance</code>
+              and be serialized in JSON.</span>
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeevent-6d">
+              The <code>id</code> field SHOULD be set to a unique identifier for
+              the event, for use when re-establishing a dropped connection (see
+              below).</span>
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeevent-6e">
+              It is RECOMMENDED that the identifier is a timestamp
+              representing the time at which the event ocurred, in the
+              &quot;date-time&quot; format specified by [[RFC3339]].</span>
           </p>
           <pre class="example">
             event: overheated\n
             data: 90\n
             id: 2021-11-16T16:53:50.817Z\n\n
           </pre>
-	  <p><span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeevent-7a">
-            If the connection between the Consumer and Web Thing drops
-            (except as a result of the <code>unsubscribe</code> operation
-            defined below), the Consumer MUST re-establish the connection
-            following the steps outlined in the Server-Sent Events specification
-            [[EVENTSOURCE]].</span>
-	  <span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeevent-7b">
-	    Once the connection is re-established the Web Thing
-            SHOULD, if possible, send any missed events which occured since
-            the last event specified by the Consumer in a
-            <code>Last-Event-ID</code> header.</span>
-      </p>
+          <p><span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeevent-7a">
+              If the connection between the Consumer and Web Thing drops
+              (except as a result of the <code>unsubscribe</code> operation
+              defined below), the Consumer MUST re-establish the connection
+              following the steps outlined in the Server-Sent Events specification
+              [[EVENTSOURCE]].</span>
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeevent-7b">
+              Once the connection is re-established the Web Thing
+              SHOULD, if possible, send any missed events which occured since
+              the last event specified by the Consumer in a
+              <code>Last-Event-ID</code> header.</span>
+          </p>
         </section>
 
         <section id="http-sse-profile-protocol-binding-events-unsubscribeevent">
           <h5><code>unsubscribeevent</code></h5>
-	  <p><span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-unsubscribeevent-1">
-            In order to unsubscribe from an event, a Consumer MUST terminate 
-            the corresponding Server-Sent Events connection with the Web Thing 
-            as specified in the Server-Sent Events specification
-            [[EVENTSOURCE]].</span>
-    </p>
-	  <p class="note" title="Terminating a connection using JavaScript">
-            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed 
+          <p><span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-unsubscribeevent-1">
+              In order to unsubscribe from an event, a Consumer MUST terminate
+              the corresponding Server-Sent Events connection with the Web Thing
+              as specified in the Server-Sent Events specification
+              [[EVENTSOURCE]].</span>
+          </p>
+          <p class="note" title="Terminating a connection using JavaScript">
+            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed
             in a runtime which exposes the
             <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface">
               <code>EventSource</code></a> interface, a Server-Sent Events
             connection can be terminated using the <code>close()</code> method
             on an <code>EventSource</code> [[EVENTSOURCE]] object.
-	  </p>
-            <pre class="example">
+          </p>
+          <pre class="example">
               overheatedEventSource.close();
             </pre>
         </section>
 
         <section id="http-sse-profile-protocol-binding-events-subscribeallevents">
           <h5><code>subscribeallevents</code></h5>
-	  <div class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeallevents-1">
-    <p>
-            The URL of an events resource to be used when subscribing to all
-            events emitted by a Web Thing MUST be obtained from a Thing
-            Description by locating a
-            <a href="https://www.w3.org/TR/wot-thing-description/#form">
-              <code>Form</code></a> inside the top level
-            <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json"><code>forms</code></a>
-            member of a Thing Description for which:
-	  </p>
-          <ul>
-            <li>
-              Its <code>op</code> member contains the value
-              <code>subscribeallevents</code>
-            </li>
-            <li>
-              After being resolved against a base URL where applicable, the
-              <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
-                scheme</a> [[RFC3986]] of the value of its <code>href</code>
-              member is <code>http</code> or <code>https</code>
-            </li>
-            <li>Its <code>subprotocol</code> member has a value of
-              <code>sse</code>
-            </li>
-          </ul>
-	  </div>
-	  <p><span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeallevents-3b">
-            The resolved value of the <code>href</code> member MUST then be used
-            as the URL of the events resource.</span>
+          <div class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeallevents-1">
+            <p>
+              The URL of an events resource to be used when subscribing to all
+              events emitted by a Web Thing MUST be obtained from a Thing
+              Description by locating a
+              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+                <code>Form</code></a> inside the top level
+              <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json"><code>forms</code></a>
+              member of a Thing Description for which:
+            </p>
+            <ul>
+              <li>
+                Its <code>op</code> member contains the value
+                <code>subscribeallevents</code>
+              </li>
+              <li>
+                After being resolved against a base URL where applicable, the
+                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                  scheme</a> [[RFC3986]] of the value of its <code>href</code>
+                member is <code>http</code> or <code>https</code>
+              </li>
+              <li>Its <code>subprotocol</code> member has a value of
+                <code>sse</code>
+              </li>
+            </ul>
+          </div>
+          <p><span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeallevents-3b">
+              The resolved value of the <code>href</code> member MUST then be used
+              as the URL of the events resource.</span>
           </p>
-	  <p><span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeallevents-4">
-            In order to subscribe to all events emitted by a Web Thing, a
-            Consumer MUST follow the Server-Sent Events [[EVENTSOURCE]]
-            specification to open a connection with the Web Thing at the URL of
-            the events resource.</span>
-    </p>
+          <p><span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeallevents-4">
+              In order to subscribe to all events emitted by a Web Thing, a
+              Consumer MUST follow the Server-Sent Events [[EVENTSOURCE]]
+              specification to open a connection with the Web Thing at the URL of
+              the events resource.</span>
+          </p>
           <p>
             This involves the Consumer sending an HTTP request to
             the Web Thing with:
@@ -3714,14 +3646,13 @@
               const lampEventsSource = new EventSource('/things/lamp/events');
             </pre>
           </p>
-	  <p><span class="rfc2119-assertion" 
-          id="http-sse-profile-protocol-binding-subscribeallevents-3">
-            If a Web Thing receives an HTTP request following the format
-            above then it MUST follow the Server-Sent Events
-            [[EVENTSOURCE]] specification to maintain an open connection with
-            the Consumer and push event data to the Consumer for all event
-            types for which it has permission to subscribe.</span>
-     </p>
+          <p><span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeallevents-3">
+              If a Web Thing receives an HTTP request following the format
+              above then it MUST follow the Server-Sent Events
+              [[EVENTSOURCE]] specification to maintain an open connection with
+              the Consumer and push event data to the Consumer for all event
+              types for which it has permission to subscribe.</span>
+          </p>
           <p>
             This involves the Web Thing initially sending an HTTP
             response to the Consumer with:
@@ -3737,66 +3668,58 @@
             HTTP/1.1 200 OK
             Content-Type: text/event-stream
           </pre>
-	  <p><span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeallevents-4a">
-            Whenever an event occurs while the Web Thing has an open connection
-            with a Consumer, the Web Thing MUST send event data to the Consumer
-            using the event stream format in the Server-Sent Events
-            [[EVENTSOURCE]] specification.</span>
-	  <span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeallevents-4b">
-	    For each message sent, the Web Thing
-            MUST set the <code>event</code> field to the 
-            name of the <code>EventAffordance</code> and populate the 
-            <code>data</code> field with event data, if any.</span>
-	  <span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeallevents-4c">
-	    The 
-            event data MUST follow the data schema specified in the
-            <code>EventAffordance</code> and be serialized in JSON.</span>
-	  <span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeallevents-4d">
-            The <code>id</code> field SHOULD be set to a unique identifier for 
-            the event, for use when re-establishing a dropped connection (see 
-            below).</span>
-    <span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeallevents-4e">
-            It is RECOMMENDED that the identifier is a timestamp 
-            representing the time at which the event ocurred, in the 
-            &quot;date-time&quot; format specified by [[RFC3339]].</span>
-      </p>
+          <p><span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeallevents-4a">
+              Whenever an event occurs while the Web Thing has an open connection
+              with a Consumer, the Web Thing MUST send event data to the Consumer
+              using the event stream format in the Server-Sent Events
+              [[EVENTSOURCE]] specification.</span>
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeallevents-4b">
+              For each message sent, the Web Thing
+              MUST set the <code>event</code> field to the
+              name of the <code>EventAffordance</code> and populate the
+              <code>data</code> field with event data, if any.</span>
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeallevents-4c">
+              The
+              event data MUST follow the data schema specified in the
+              <code>EventAffordance</code> and be serialized in JSON.</span>
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeallevents-4d">
+              The <code>id</code> field SHOULD be set to a unique identifier for
+              the event, for use when re-establishing a dropped connection (see
+              below).</span>
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeallevents-4e">
+              It is RECOMMENDED that the identifier is a timestamp
+              representing the time at which the event ocurred, in the
+              &quot;date-time&quot; format specified by [[RFC3339]].</span>
+          </p>
           <pre class="example">
             event: overheated\n
             data: 90\n
             id: 2021-11-16T16:53:50.817Z\n\n
           </pre>
-	  <p><span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeallevents-5a">
-            If the connection between the Consumer and Web Thing drops
-            (except as a result of the <code>unsubscribeallevents</code>
-            operation defined below), the Consumer MUST re-establish the
-            connection following the steps outlined in the Server-Sent Events
-            specification [[EVENTSOURCE]].</span>
-	  <span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-subscribeallevents-5b">
-	    Once the connection is re-established
-            the Web Thing SHOULD, if possible, send any missed events which
-            occured since the last event specified by the Consumer in a
-            <code>Last-Event-ID</code> header.</span>
-        </p>
+          <p><span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeallevents-5a">
+              If the connection between the Consumer and Web Thing drops
+              (except as a result of the <code>unsubscribeallevents</code>
+              operation defined below), the Consumer MUST re-establish the
+              connection following the steps outlined in the Server-Sent Events
+              specification [[EVENTSOURCE]].</span>
+            <span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-subscribeallevents-5b">
+              Once the connection is re-established
+              the Web Thing SHOULD, if possible, send any missed events which
+              occured since the last event specified by the Consumer in a
+              <code>Last-Event-ID</code> header.</span>
+          </p>
         </section>
 
         <section id="http-sse-profile-protocol-binding-events-unsubscribeallevents">
           <h5><code>unsubscribeallevents</code></h5>
-	  <p><span class="rfc2119-assertion" 
-            id="http-sse-profile-protocol-binding-unsubscribeallevents-1">
-            In order to unsubscribe from all events, a Consumer MUST terminate 
-            the corresponding Server-Sent Events connection with the events 
-            endpoint of the Web Thing, following the steps specified in the 
-            Server-Sent Events specification [[EVENTSOURCE]].</span>
-    </p>
-	  <p class="note" title="Terminating a connection using JavaScript">
-            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed 
+          <p><span class="rfc2119-assertion" id="http-sse-profile-protocol-binding-unsubscribeallevents-1">
+              In order to unsubscribe from all events, a Consumer MUST terminate
+              the corresponding Server-Sent Events connection with the events
+              endpoint of the Web Thing, following the steps specified in the
+              Server-Sent Events specification [[EVENTSOURCE]].</span>
+          </p>
+          <p class="note" title="Terminating a connection using JavaScript">
+            For Consumers implemented in JavaScript [[ECMASCRIPT]] and executed
             in a runtime which exposes the
             <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface">
               <code>EventSource</code></a> interface, a Server-Sent Events
@@ -3805,7 +3728,7 @@
           <pre class="example">
               lampEventsSource.close();
             </pre>
-	  </p>
+          </p>
         </section>
       </section>
     </section>
@@ -3821,14 +3744,14 @@
       <a href="#sec-http-webhook-profile">WebHooks</a>.
     </p>
     <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-general-1">
-      The <em>HTTP Webhook profile</em> MAY be used in conjunction with the
-      <a href="#http-baseline-profile">HTTP Baseline Profile</a> in order to
-      provide operations to read and write properties and invoke, query and
-      cancel actions.</span>
+        The <em>HTTP Webhook profile</em> MAY be used in conjunction with the
+        <a href="#http-baseline-profile">HTTP Baseline Profile</a> in order to
+        provide operations to read and write properties and invoke, query and
+        cancel actions.</span>
     </p>
     <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-general-2">
-      The <em>HTTP Webhook profile</em> MAY be used as an alternative event mechanism
-      to the <a href="#sec-http-sse-profile">HTTP SSE Profile</a>.</span>
+        The <em>HTTP Webhook profile</em> MAY be used as an alternative event mechanism
+        to the <a href="#sec-http-sse-profile">HTTP SSE Profile</a>.</span>
     </p>
     <!-- Web Thing Webhooks  -->
     <section id="sec-http-webhook-profile-intro">
@@ -3847,8 +3770,8 @@
         Create normative language on multiple subscriptions to the same event by the same consumer.
       </p>
       <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-events-1">
-        Depending on the use case, a single listener for multiple things and multiple
-        event types MAY be used.</span>
+          Depending on the use case, a single listener for multiple things and multiple
+          event types MAY be used.</span>
       </p>
 
       <section id="webhook-example">
@@ -3870,10 +3793,11 @@
         </figure>
 
 
-        <p>The following example contains a snippet from a TD that illustrates how a Webhook event can be described.</p>
+        <p>The following example contains a snippet from a TD that illustrates how a Webhook event can be described.
+        </p>
         <pre class="example">
             ...
-    
+
             {
                 "events": {
                     "fireAlarm": {
@@ -3898,7 +3822,7 @@
                             "type": "string",
                             "description": "sprinkler status"
                         },
-            
+
                         "cancellation": {
                           "type": "object",
                           "properties": {
@@ -3935,12 +3859,12 @@
     <section id="http-webhook-profile-identifier">
       <h2>Identifier</h2>
       <p><span class="rfc2119-assertion" id="http-webhook-profile-1">
-        In order to denote that a given
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
-        conforms to the HTTP Webhook Profile, its Thing Description MUST have a
-        <a href="https://w3c.github.io/wot-thing-description/#thing">
-          <code>profile</code></a> member [[wot-thing-description]] with a value
-        of <code>https://www.w3.org/2022/wot/profile/http-webhook/v1</code>.</span>
+          In order to denote that a given
+          <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+          conforms to the HTTP Webhook Profile, its Thing Description MUST have a
+          <a href="https://w3c.github.io/wot-thing-description/#thing">
+            <code>profile</code></a> member [[wot-thing-description]] with a value
+          of <code>https://www.w3.org/2022/wot/profile/http-webhook/v1</code>.</span>
       </p>
       <section class="note">
         <p>Note that the <code>profile</code> member is an array that may contain multiple
@@ -3953,109 +3877,110 @@
       <p>
         This section defines a JSON object format for events.
       </p>
-    <p class="rfc2119-assertion" id="http-webhook-profile-message-format-1">
+      <p class="rfc2119-assertion" id="http-webhook-profile-message-format-1">
         Event notification messages MUST comply with the following data schema.
       </p>
 
-        <p>
-          The format is aligned with the <a href="https://cloudevents.io/">cloud events specification</a> 
-          to ensure interoperability with cloud systems that adopt that specification.
-        </p>
-        <p>
-          An event message contains a set of metadata properties and an optional data payload.
-          The metadata fields allow to determine the type and source of the event as well as
-          a timestamp indicating when the event occured and an optional data payload.
-        </p>
-        <p>
-          <span class="rfc2119-assertion" id="profile-json-event-payload">
-            The following constraints MUST be
-            applied to the event payload:
-          </span>
-        </p>
-        <table class="def">
-          <thead>
-            <tr>
-              <th>keyword</th>
-              <th>type</th>
-              <th>type constraints</th>
-              <th>value constraints</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>specversion</td>
-              <td>string</td>
-              <td>mandatory, non-empty</td>
-              <td>The <code>specversion</code> MUST have the value "1.0"</td>
-            </tr>
-            <tr>
-              <td>id</td>
-              <td>string</td>
-              <td>mandatory, non-empty</td>
-              <td>For each distinct event the combination of <code>source</code> + <code>id</code> MUST be unique. 
-                A WebThing MAY resend the same event with the same <code>id</code>. 
-                If an event is resent with the same <code>id</code>, a consumer SHOULD treat it as
-                duplicate.</td>
-            </tr>
-            <tr>
-              <td>source</td>
-              <td>uri</td>
-              <td>mandatory, non-empty</td>
-              <td>The combination of <code>source</code> + <code>id</code> MUST be unique for each distinct event. 
-                The source MUST be set to the <code>baseURI</code> of the WebThing.</td>
-            </tr>
-            <tr>
-              <td>subject</td>
-              <td>string</td>
-              <td>optional</td>
-              <td>When this field is used, it MUST be set to the <code>title</code> of the event or property
-                affordance.</td>
-            </tr>
-            <tr>
-              <td>type</td>
-              <td>string</td>
-              <td>mandatory, non-empty</td>
-              <td>For event affordances the source MUST be set to the string "/events/<code>eventName</code>" of the
-                event affordance.</br>
-                For property affordances the source MUST be set to the string "/properties/<code>propertyName</code>" of
-                the property affordance.
-              </td>
-            </tr>
-            <tr>
-              <td>time</td>
-              <td>string</td>
-              <td>optional, compliant with [[RFC3339]]</td>
-              <td>time when the event occurred. If the WebThing does not have a clock, it MUST use the same
-                algorithm on all event affordances to determine the value of this field.
-            </tr>
-            <tr>
-              <td>datacontenttype</td>
-              <td>string</td>
-              <td>optional, [[RFC2046]] compliant MIME type, when set the value MUST be "<code>application/json</code>"</td>
-              <td>If a WebThing contains a <code>data member</code>, this field MUST be present.</td>
-            </tr>
-            <tr>
-              <td>data</td>
-              <td>string</td>
-              <td>optional</td>
-              <td>JSON encoded <code>data</code> object of the event affordance.</td>
-            </tr>
-          </tbody>
-        </table>
-        <span class="rfc2119-assertion" id="profile-event-payload-size">
-          The size of an event object MUST NOT exceed 64KB, to ensure interoperability with all kinds of consumers.
+      <p>
+        The format is aligned with the <a href="https://cloudevents.io/">cloud events specification</a>
+        to ensure interoperability with cloud systems that adopt that specification.
+      </p>
+      <p>
+        An event message contains a set of metadata properties and an optional data payload.
+        The metadata fields allow to determine the type and source of the event as well as
+        a timestamp indicating when the event occured and an optional data payload.
+      </p>
+      <p>
+        <span class="rfc2119-assertion" id="profile-json-event-payload">
+          The following constraints MUST be
+          applied to the event payload:
         </span>
+      </p>
+      <table class="def">
+        <thead>
+          <tr>
+            <th>keyword</th>
+            <th>type</th>
+            <th>type constraints</th>
+            <th>value constraints</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>specversion</td>
+            <td>string</td>
+            <td>mandatory, non-empty</td>
+            <td>The <code>specversion</code> MUST have the value "1.0"</td>
+          </tr>
+          <tr>
+            <td>id</td>
+            <td>string</td>
+            <td>mandatory, non-empty</td>
+            <td>For each distinct event the combination of <code>source</code> + <code>id</code> MUST be unique.
+              A WebThing MAY resend the same event with the same <code>id</code>.
+              If an event is resent with the same <code>id</code>, a consumer SHOULD treat it as
+              duplicate.</td>
+          </tr>
+          <tr>
+            <td>source</td>
+            <td>uri</td>
+            <td>mandatory, non-empty</td>
+            <td>The combination of <code>source</code> + <code>id</code> MUST be unique for each distinct event.
+              The source MUST be set to the <code>baseURI</code> of the WebThing.</td>
+          </tr>
+          <tr>
+            <td>subject</td>
+            <td>string</td>
+            <td>optional</td>
+            <td>When this field is used, it MUST be set to the <code>title</code> of the event or property
+              affordance.</td>
+          </tr>
+          <tr>
+            <td>type</td>
+            <td>string</td>
+            <td>mandatory, non-empty</td>
+            <td>For event affordances the source MUST be set to the string "/events/<code>eventName</code>" of the
+              event affordance.</br>
+              For property affordances the source MUST be set to the string "/properties/<code>propertyName</code>" of
+              the property affordance.
+            </td>
+          </tr>
+          <tr>
+            <td>time</td>
+            <td>string</td>
+            <td>optional, compliant with [[RFC3339]]</td>
+            <td>time when the event occurred. If the WebThing does not have a clock, it MUST use the same
+              algorithm on all event affordances to determine the value of this field.
+          </tr>
+          <tr>
+            <td>datacontenttype</td>
+            <td>string</td>
+            <td>optional, [[RFC2046]] compliant MIME type, when set the value MUST be "<code>application/json</code>"
+            </td>
+            <td>If a WebThing contains a <code>data member</code>, this field MUST be present.</td>
+          </tr>
+          <tr>
+            <td>data</td>
+            <td>string</td>
+            <td>optional</td>
+            <td>JSON encoded <code>data</code> object of the event affordance.</td>
+          </tr>
+        </tbody>
+      </table>
+      <span class="rfc2119-assertion" id="profile-event-payload-size">
+        The size of an event object MUST NOT exceed 64KB, to ensure interoperability with all kinds of consumers.
+      </span>
       <p class="rfc2119-assertion" id="http-webhook-profile-message-format-2">
         For each notification message, the Web Thing MUST set the <code>event</code> field to the
         name of the <code>EventAffordance</code>.</span>
       </p>
       <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-message-format-3">
-        The event <code>data</code> MUST follow the data schema specified in the
-        <code>EventAffordance</code> and MUST be serialized in JSON.</span>
+          The event <code>data</code> MUST follow the data schema specified in the
+          <code>EventAffordance</code> and MUST be serialized in JSON.</span>
       </p>
       <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-message-format-4">
-        The <code>id</code> field MUST be set to a unique identifier for
-        the event.</span>
+          The <code>id</code> field MUST be set to a unique identifier for
+          the event.</span>
       </p>
     </section>
 
@@ -4080,39 +4005,39 @@
         <section id="http-webhook-profile-protocol-binding-subscribeevent">
           <h4><code>subscribeevent</code></h4>
           <div class="rfc2119-assertion" id="http-baseline-profile-protocol-binding-subscribeevent-1">
-          <p>
-            The URL of an <code>Event</code> resource to be used when
-            subscribing to an event MUST be obtained from a Thing Description
-            by locating a
-            <a href="https://www.w3.org/TR/wot-thing-description/#form">
-              <code>Form</code></a> inside the corresponding
-            <a href="https://www.w3.org/TR/wot-thing-description/#eventaffordance">
-              <code>EventAffordance</code></a> for which:
-          </p>
-          <ul>
-            <li>
-              After defaults have been applied, its <code>op</code> member
-              contains the value <code>subscribeevent</code>
-            </li>
-            <li>
-              After being resolved against a base URL where applicable, the
-              <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
-                scheme</a> [[RFC3986]] of the value of its <code>href</code>
-              member is <code>http</code> or <code>https</code>
-            </li>
-            <li>Its <code>subprotocol</code> member has a value of
-              <code>"webhook"</code>
-            </li>
-          </ul>
+            <p>
+              The URL of an <code>Event</code> resource to be used when
+              subscribing to an event MUST be obtained from a Thing Description
+              by locating a
+              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+                <code>Form</code></a> inside the corresponding
+              <a href="https://www.w3.org/TR/wot-thing-description/#eventaffordance">
+                <code>EventAffordance</code></a> for which:
+            </p>
+            <ul>
+              <li>
+                After defaults have been applied, its <code>op</code> member
+                contains the value <code>subscribeevent</code>
+              </li>
+              <li>
+                After being resolved against a base URL where applicable, the
+                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                  scheme</a> [[RFC3986]] of the value of its <code>href</code>
+                member is <code>http</code> or <code>https</code>
+              </li>
+              <li>Its <code>subprotocol</code> member has a value of
+                <code>"webhook"</code>
+              </li>
+            </ul>
           </div>
           <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-subscribeevent-3">
-            The resolved value of the <code>href</code> member MUST then be used
-            as the URL of the <code>Event</code> resource.</span>
+              The resolved value of the <code>href</code> member MUST then be used
+              as the URL of the <code>Event</code> resource.</span>
           </p>
           <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-subscribeevent-4">
-            In order to subscribe to an event, a Consumer MUST
-            provide the listener URL in the data payload of the
-            <code>subscribe</code> operation of the <code>Event</code> resource.</span>
+              In order to subscribe to an event, a Consumer MUST
+              provide the listener URL in the data payload of the
+              <code>subscribe</code> operation of the <code>Event</code> resource.</span>
           </p>
           <p>
             This involves the Consumer sending an HTTP request to
@@ -4137,7 +4062,7 @@
               POST /things/lamp/events/overheated HTTP/1.1
               Host: mythingserver.com
               Accept: application/json
-              
+
               {
                 "properties": {
                   ...
@@ -4148,10 +4073,10 @@
               </pre>
 
           <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-subscribeevent-5">
-            If a Web Thing receives an HTTP request following the format
-            above and the Consumer has permission to subscribe to the
-            corresponding event, then it MUST send <em>event messages</em>
-            to the Consumer as events of the specified type are emitted.</span>
+              If a Web Thing receives an HTTP request following the format
+              above and the Consumer has permission to subscribe to the
+              corresponding event, then it MUST send <em>event messages</em>
+              to the Consumer as events of the specified type are emitted.</span>
           </p>
 
           <p>
@@ -4169,16 +4094,16 @@
           <pre class="example">
               HTTP/1.1 200 OK
               Content-Type: application/json
-    
+
               {
                   subscriptionId: 1234-4544-1211
               }
-    
+
               </pre>
           <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-subscribeevent-6">
-            Whenever an event of the specified type occurs, the Web Thing MUST
-            send event data to the Consumer using the event payload format defined in section
-            ["#sec-http-webhook-profile-protocol-binding-events-notification"].</span>
+              Whenever an event of the specified type occurs, the Web Thing MUST
+              send event data to the Consumer using the event payload format defined in section
+              ["#sec-http-webhook-profile-protocol-binding-events-notification"].</span>
           </p>
 
         </section>
@@ -4187,9 +4112,9 @@
           <h4><code>unsubscribeevent</code></h4>
 
           <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-subscribeevent-4b">
-            In order to unsubscribe to an event, a Consumer MUST
-            provide the <code>subscriptionID</code> in the data payload of the
-            <code>unsubscribe</code> operation of the <code>Event</code> resource.</span>
+              In order to unsubscribe to an event, a Consumer MUST
+              provide the <code>subscriptionID</code> in the data payload of the
+              <code>unsubscribe</code> operation of the <code>Event</code> resource.</span>
           </p>
           <p>
             This involves the Consumer sending an HTTP request to
@@ -4206,8 +4131,8 @@
               object with a valid <code>subscriptionId</code>.
             </li>
             <p class="ednote">
-            <!-- TODO: define subscriptionId format - urn? -->
-            TODO: define subscriptionId format - urn?
+              <!-- TODO: define subscriptionId format - urn? -->
+              TODO: define subscriptionId format - urn?
             </p>
           </ul>
         </section>
@@ -4215,57 +4140,57 @@
         <section id="http-webhook-profile-protocol-binding-events-subscribeallevents">
           <h4><code>subscribeallevents</code></h4>
           <div class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-subscribeallevents-1">
-          <p>
-            The URL of an <code>Events</code> resource to be used when subscribing to all
-            events emitted by a Web Thing MUST be obtained from a Thing
-            Description by locating a
-            <a href="https://www.w3.org/TR/wot-thing-description/#form">
-              <code>Form</code></a> inside the top level
-            <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json"><code>forms</code></a>
-            member of a Thing Description for which:
-          </p>
-          <ul>
-            <li>
-              Its <code>op</code> member contains the value
-              <code>subscribeallevents</code>
-            </li>
-            <li>
-              After being resolved against a base URL where applicable, the
-              <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
-                scheme</a> [[RFC3986]] of the value of its <code>href</code>
-              member is <code>http</code> or <code>https</code>
-            </li>
-            <li>Its <code>subprotocol</code> member has a value of
-              <code>"sse"</code>
-            </li>
-          </ul>
+            <p>
+              The URL of an <code>Events</code> resource to be used when subscribing to all
+              events emitted by a Web Thing MUST be obtained from a Thing
+              Description by locating a
+              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+                <code>Form</code></a> inside the top level
+              <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json"><code>forms</code></a>
+              member of a Thing Description for which:
+            </p>
+            <ul>
+              <li>
+                Its <code>op</code> member contains the value
+                <code>subscribeallevents</code>
+              </li>
+              <li>
+                After being resolved against a base URL where applicable, the
+                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                  scheme</a> [[RFC3986]] of the value of its <code>href</code>
+                member is <code>http</code> or <code>https</code>
+              </li>
+              <li>Its <code>subprotocol</code> member has a value of
+                <code>"sse"</code>
+              </li>
+            </ul>
           </div>
           <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-subscribeallevents-3">
-            The resolved value of the <code>href</code> member MUST then be used
-            as the URL of the events resource.</span>
+              The resolved value of the <code>href</code> member MUST then be used
+              as the URL of the events resource.</span>
           </p>
           <div class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-subscribeallevents-4">
-          <p>
-            In order to subscribe to <em>all</em> events emitted by a Web Thing, a
-            Consumer MUST send an HTTP request to the Web Thing with:
-          </p>
-          <ul>
-            <li>Method set to <code>POST</code></li>
-            <li>URL set to the URL of the events resource</li>
-            <li>
-              <code>Accept</code> header set to <code>text/event-stream</code>
-            </li>
-            <li>
-              <code>Request Payload</code> contains a <code>JSON</code>
-              object with a subscription payload.
-            </li>
-          </ul>
+            <p>
+              In order to subscribe to <em>all</em> events emitted by a Web Thing, a
+              Consumer MUST send an HTTP request to the Web Thing with:
+            </p>
+            <ul>
+              <li>Method set to <code>POST</code></li>
+              <li>URL set to the URL of the events resource</li>
+              <li>
+                <code>Accept</code> header set to <code>text/event-stream</code>
+              </li>
+              <li>
+                <code>Request Payload</code> contains a <code>JSON</code>
+                object with a subscription payload.
+              </li>
+            </ul>
           </div>
           <pre class="example">
                 POST /things/lamp/events/overheated HTTP/1.1
                 Host: mythingserver.com
                 Accept: application/json
-                
+
                 {
                   "properties": {
                     ...
@@ -4276,10 +4201,10 @@
                 </pre>
 
           <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-subscribeallevents-5">
-            If a Web Thing receives an HTTP request following the format
-            above, then it MUST send <em>event messages</em>
-            to the Consumer for all event
-            types for which it has permission to subscribe.</span>
+              If a Web Thing receives an HTTP request following the format
+              above, then it MUST send <em>event messages</em>
+              to the Consumer for all event
+              types for which it has permission to subscribe.</span>
           </p>
           <p>
             This involves the Web Thing initially sending an HTTP
@@ -4297,34 +4222,35 @@
           <pre class="example">
                 HTTP/1.1 200 OK
                 Content-Type: text/event-stream
-    
+
                 {
                   subscriptionId: 1234-4544-1211
                 }
-    
+
               </pre>
 
           <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-subscribeallevents-6">
-            Whenever an event occurs, the Web Thing MUST send event data to the Consumer
-            using the event payload format defined in section <a href="sec-http-webhook-profile-message-format">Message Format</a>.</span>
+              Whenever an event occurs, the Web Thing MUST send event data to the Consumer
+              using the event payload format defined in section <a
+                href="sec-http-webhook-profile-message-format">Message Format</a>.</span>
 
           <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-subscribeallevents-7">
-            If the connection between the Web Thing and the Consumer drops,
-            the Web Thing MUST re-establish the connection.</span>
+              If the connection between the Web Thing and the Consumer drops,
+              the Web Thing MUST re-establish the connection.</span>
           </p>
 
           <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-subscribeallevents-8">
-            Once the connection is re-established the Web Thing
-            SHOULD, if possible, send any missed events which occured since
-            the last succesful event notification.</span>
+              Once the connection is re-established the Web Thing
+              SHOULD, if possible, send any missed events which occured since
+              the last succesful event notification.</span>
           </p>
         </section>
 
         <section id="http-webhook-profile-protocol-binding-events-unsubscribeallevents">
           <h4><code>unsubscribeallevents</code></h4>
           <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-unsubscribeallevents-1">
-            In order to unsubscribe from all events, a Consumer MUST invoke the
-            <code>unsubscribe</code> operation of the <code>Event</code> resource.</span>
+              In order to unsubscribe from all events, a Consumer MUST invoke the
+              <code>unsubscribe</code> operation of the <code>Event</code> resource.</span>
           </p>
 
           <p>
@@ -4353,43 +4279,44 @@
         <h4>Event Connections</h4>
 
         <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-event-connections-1">
-          A HTTP(s) connection to the event listener of a Consumer MUST be initiated and managed by the Web Thing.</span>
+            A HTTP(s) connection to the event listener of a Consumer MUST be initiated and managed by the Web
+            Thing.</span>
         </p>
 
         <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-event-connections-2">
-          A Consumer MUST terminate the subscription with the events endpoint of the Web Thing.</span>
+            A Consumer MUST terminate the subscription with the events endpoint of the Web Thing.</span>
         </p>
         <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-event-connections-3">
-          If a Consumer becomes unavailable and the Web Thing cannot successfully transmit
-          event messages to the consumer, it SHOULD attempt several retries at increasing intervals.</span>
+            If a Consumer becomes unavailable and the Web Thing cannot successfully transmit
+            event messages to the consumer, it SHOULD attempt several retries at increasing intervals.</span>
         </p>
         <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-event-connections-4">
-          After the maximum number of retries was reached, the Web Thing MAY terminate the subscription
-          without having received an <code>unsubscribe</code> or <code>unsubscribeall</code> operation.</span>
+            After the maximum number of retries was reached, the Web Thing MAY terminate the subscription
+            without having received an <code>unsubscribe</code> or <code>unsubscribeall</code> operation.</span>
         </p>
         <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding--event-connections-5">
-          If the connection between the Web Thing and the Consumer drops,
-          the Web Thing MUST attempt to re-establish the connection.</span>
+            If the connection between the Web Thing and the Consumer drops,
+            the Web Thing MUST attempt to re-establish the connection.</span>
         </p>
         <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-event-connections-6">
-          Once the connection is re-established, the Web Thing
-          SHOULD, if possible, send any missed events which occured since
-          the last succesful event notification.</span>
+            Once the connection is re-established, the Web Thing
+            SHOULD, if possible, send any missed events which occured since
+            the last succesful event notification.</span>
         </p>
         <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-event-connections-7">
-          The Web Thing MAY reuse an existing connection to a listener for subsequent message traffic,
-          or it MAY establish a new connection for each message.</span>
+            The Web Thing MAY reuse an existing connection to a listener for subsequent message traffic,
+            or it MAY establish a new connection for each message.</span>
         </p>
         <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding--event-connections-8">
-          When an event message has been received, the Consumer MUST respond with a "HTTP 200 OK" message.</span>
+            When an event message has been received, the Consumer MUST respond with a "HTTP 200 OK" message.</span>
         </p>
         <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-event-connections-9">
-          An (optional) JSON payload MAY be provided to return a response back to the Web Thing
-          via the same communication channel.</span>
+            An (optional) JSON payload MAY be provided to return a response back to the Web Thing
+            via the same communication channel.</span>
         </p>
       </section>
     </section>
-  </section> 
+  </section>
 
   <!---------------------------------------------------------------->
   </section>


### PR DESCRIPTION
This looks like a big diff but it's basically just:
1. Fixing indentation and whitespace (Ctrl+Shift+I in VSCode using default settings) since a recent PR messed it up
2. Adding a missing closing `</section>` tag (This moves HTTP SSE Profile and HTTP Webhook Profile back out into their own sections as they were supposed to be, fixing #214)

There's still a separate HTTP Profile section, which I think needs further discussion in #244.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/249.html" title="Last updated on Aug 3, 2022, 2:57 PM UTC (6187d0e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/249/37138a5...benfrancis:6187d0e.html" title="Last updated on Aug 3, 2022, 2:57 PM UTC (6187d0e)">Diff</a>