### PR TITLE
Add missing form for observeallproperties and unobserveallproperties

### DIFF
--- a/index.html
+++ b/index.html
@@ -3101,6 +3101,11 @@
               "href": "properties"
             },
             {
+              "op": ["observeallproperties", "unobserveallproperties"],
+              "href": "properties",
+              "subprotocol": "sse"
+            },
+            {
               "op": "queryallactions",
               "href": "actions"
             },


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/263.html" title="Last updated on Aug 17, 2022, 1:57 PM UTC (71f69e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/263/dd16402...benfrancis:71f69e4.html" title="Last updated on Aug 17, 2022, 1:57 PM UTC (71f69e4)">Diff</a>