### PR TITLE
Add geolocation semantic annotation recommendation - closes #137

### DIFF
--- a/index.html
+++ b/index.html
@@ -1831,12 +1831,56 @@
 
     <section id="common-constraints-semantic-annotations">
       <h2>Semantic Annotations</h2>
-      <p class="ednote">
-        TODO: Define a set of recommended semantic ontologies for common
-        vocabulary such as
-        <a href="https://github.com/w3c/wot-profile/issues/137">geolocation</a>
-        and <a href="https://github.com/w3c/wot-profile/issues/29">units</a>.
-      </p>
+      <section id="common-constraints-semantic-annotations-geolocation">
+        <h3>Geolocation</h3>
+        <p>
+          <span class="rfc2119-assertion" id="common-constraints-errors-7">
+            It is RECOMMENDED that where geolocation metadata is needed, the 
+            schema.org [[schema-org]] ontology is used.
+          </span>
+        </p>
+        <pre class="example" title="Geolocation annotations on a Thing">
+          {
+            "@context": [
+              "https://www.w3.org/2022/wot/td/v1.1",
+              {
+                "schema": "https://schema.org"
+              }
+            ],
+            "schema:longitude": "297.83",
+            "schema:latitude": "26.58",
+            "schema:elevation": "5.3"
+          }
+        </pre>
+        <pre class="example" title="Geolocation annotations on a PropertyAffordance">
+          {
+            "@context": [
+              "https://www.w3.org/2022/wot/td/v1.1",
+              {
+                "schema": "https://schema.org"
+              }
+            ],
+            "properties": {
+              "position": {
+                "type": "object",
+                "@type": "schema:GeoCoordinates",
+                "properties": {
+                  "longitude": { "type": "number" },
+                  "latitude":  { "type": "number" },
+                  "elevation": { "type": "number" }
+                }
+              },
+            },
+          }
+        </pre>
+      </section>
+      <section id="common-constraints-semantic-annotations-units">
+        <h2>Units</h2>
+        <p class="ednote">
+          TODO: Define a recommended semantic ontology for 
+          <a href="https://github.com/w3c/wot-profile/issues/29">units</a>.
+        </p>
+      </section>
     </section>
 
     <section id="sec-default-language">


### PR DESCRIPTION
This assertion recommends the use of the schema.org ontology for geolocation semantic annotations, as discussed in #17 and #137.

I've included two examples of how to use the geolocation annotations which I think are equally valid:
1. To add static geolocation metadata to a Thing at the top level of its Thing Description
2. To add a dynamic geolocation property to a Thing as a PropertyAffordance

Note that this PR depends on #260 which adds a Semantic Annotations section under Common Constraints. Please only review the final commit https://github.com/w3c/wot-profile/commit/cfa5716c9809364647d55b6c1eb1fea564a6fd2f


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/264.html" title="Last updated on Aug 31, 2022, 11:50 AM UTC (6bc99ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/264/68e06a2...benfrancis:6bc99ec.html" title="Last updated on Aug 31, 2022, 11:50 AM UTC (6bc99ec)">Diff</a>