### PR TITLE
make hreflang optional - closes #245

### DIFF
--- a/index.html
+++ b/index.html
@@ -1684,7 +1684,7 @@
           <tr>
             <td><code>hreflang</code></td>
             <td><code>array of string</code> with valid language tags according to [BCP47]</td>
-            <td>mandatory.</td>
+            <td>optional.</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
Fixes issue #245


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/pull/273.html" title="Last updated on Sep 5, 2022, 1:09 PM UTC (8034fcf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/273/f7348cf...8034fcf.html" title="Last updated on Sep 5, 2022, 1:09 PM UTC (8034fcf)">Diff</a>