### PR TITLE
editorial alignment - consistent use of "WoT Profile Specification" - closes #244

### DIFF
--- a/index.html
+++ b/index.html
@@ -1642,7 +1642,7 @@
       <p>
         <span class="rfc2119-assertion" id="common-constraints-links-2">Other keywords for links MAY
           be present in a TD, however their interpretation is undefined
-          in the context of the HTTP profile</span>
+          in the context of the HTTP profiles</span>
         <span class="rfc2119-assertion" id="common-constraints-links-3">These keywords MAY
           be ignored by all profile-compliant consumers.</span>
       </p>
@@ -1738,7 +1738,7 @@
           are defined for the link targets of compliant TDs. They MUST be supported by all consumers.</span>
         <span class="rfc2119-assertion" id="common-constraints-links-media-types-2">Other media types MAY be present in a TD. </span>
         <span class="rfc2119-assertion" id="common-constraints-links-media-types-3">Their interpretation is undefined
-          in the context of the HTTP profile and they MAY be ignored by all profile-compliant consumers.</span>
+          in the context of the HTTP profiles and they MAY be ignored by all profile-compliant consumers.</span>
         <table class="def">
           <thead>
             <tr>

--- a/index.html
+++ b/index.html
@@ -417,7 +417,7 @@
       </p>
       <p>
         Devices created by various engineers, vendors and SDOs that satisfy the requirements
-        of the profile spec can be integrated with compliant consumers without additional customization.
+        of the profile specification can be integrated with compliant consumers without additional customization.
         This works across infrastructures, regions and cultures.
       </p>
     </section>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/pull/274.html" title="Last updated on Sep 14, 2022, 12:12 PM UTC (e9647a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/274/f7348cf...e9647a5.html" title="Last updated on Sep 14, 2022, 12:12 PM UTC (e9647a5)">Diff</a>