### PR TITLE
remove http-webhook-profile-protocol-binding-general-2 assertion - closes issue #229

### DIFF
--- a/index.html
+++ b/index.html
@@ -2813,8 +2813,8 @@
         provide operations to read and write properties and invoke, query and
         cancel actions.</span>
     </p>
-    <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-general-2">
-        The <em>HTTP Webhook profile</em> MAY be used as an alternative event mechanism
+    <p>
+        The <em>HTTP Webhook profile</em> may be used as an alternative event mechanism
         to the <a href="#sec-http-sse-profile">HTTP SSE Profile</a>.</span>
     </p>
     <p>


### PR DESCRIPTION
resolves issue #229


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/pull/277.html" title="Last updated on Sep 7, 2022, 1:25 PM UTC (889e12a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/277/8b8e1aa...889e12a.html" title="Last updated on Sep 7, 2022, 1:25 PM UTC (889e12a)">Diff</a>