### PR TITLE
Refine Profile definition - closes #243

### DIFF
--- a/index.html
+++ b/index.html
@@ -489,21 +489,6 @@
         interoperable</a> with any <a href="#dfn-thing">Thing</a> which also
         conforms with those assertions.
       </dd>
-
-      <dt>
-        <dfn>Baseline Profile</dfn>
-      </dt>
-      <dd>
-        Synonym for <a>HTTP Baseline Profile</a>
-      </dd>
-
-      <dt>
-        <dfn>HTTP Baseline Profile</dfn>
-      </dt>
-      <dd>The subset of the Thing Description
-        defined by the present document.
-      </dd>
-
     </dl>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -483,9 +483,11 @@
       <dt>
         <dfn class="export">Profile</dfn>
       </dt>
-      <dd>A set of prescriptive rules, to ensure that
-        compliant implementations satisfy the semantic
-        guarantees that are implied by them.
+      <dd>A technical specification which provides a set of assertions such that
+        any <a href="#dfn-consumer">Consumer</a> which conforms with the those 
+        assertions is <a href="#out-of-the-box-interoperability">out-of-the-box 
+        interoperable</a> with any <a href="#dfn-thing">Thing</a> which also
+        conforms with those assertions.
       </dd>
 
       <dt>


### PR DESCRIPTION
I've updated the definition of the term "profile" as suggested in #243.

I've also (in a separate commit) removed the definitions of the term "HTTP Baseline Profile", since:
1. The current definition still refers to the profile as "The subset of the Thing Description"
2. It's strange that we have a definition of the HTTP Baseline Profile and not the other profiles
3. It's really just a the title of a section in the specification, not a term that needs a definition as such

(I can remove the second commit if anyone disagrees).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/278.html" title="Last updated on Sep 7, 2022, 5:01 PM UTC (d4a2820)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/278/8b8e1aa...benfrancis:d4a2820.html" title="Last updated on Sep 7, 2022, 5:01 PM UTC (d4a2820)">Diff</a>