### PR TITLE
Clarify that href member of ActionStatus can be used by cancelaction - closes #283

### DIFF
--- a/index.html
+++ b/index.html
@@ -1600,9 +1600,9 @@
                 <tr class="rfc2119-table-assertion" id="http-baseline-profile-protocol-binding-invokeaction-12_4">
                   <td><code>href</code></td>
                   <td>
-                    The [[URL]] of an <code>ActionStatus</code> resource which can
-                    be polled with a <code>queryaction</code> operation to get
-                    the latest status of the action, the
+                    The [[URL]] of an <code>ActionStatus</code> resource which
+                    can be used by <code>queryaction</code> and 
+                    <code>cancelaction</code> operations, the
                     <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
                       scheme</a> [[RFC3986]] of which MUST resolve to
                     <code>http</code> or <code>https</code> (only needed for an


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/286.html" title="Last updated on Sep 21, 2022, 9:49 AM UTC (5835ea6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/286/8b8e1aa...benfrancis:5835ea6.html" title="Last updated on Sep 21, 2022, 9:49 AM UTC (5835ea6)">Diff</a>