### PR TITLE
Remove empty Semantic Annotations section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1001,17 +1001,6 @@
       </p>
     </section>
 
-    <!-- Semantic Annotations -->
-    <section id="common-constraints-semantic-annotations">
-      <h2>Semantic Annotations</h2>
-      <p class="ednote">
-        TODO: Define a set of recommended semantic ontologies for common
-        vocabulary such as
-        <a href="https://github.com/w3c/wot-profile/issues/137">geolocation</a>
-        and <a href="https://github.com/w3c/wot-profile/issues/29">units</a>.
-      </p>
-    </section>
-
       <!-- Default Language -->
     <section id="sec-default-language">
       <h2>Default Language</h2>


### PR DESCRIPTION
Since the suggested recommendations about semantic contexts in #29 (units) and #137 (geolocation) have been deferred until WoT Profile 1.1, I propose removing the empty Semantic Annotations section and closing PR #264.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/288.html" title="Last updated on Sep 21, 2022, 11:02 AM UTC (5edc1a4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/288/8b8e1aa...benfrancis:5edc1a4.html" title="Last updated on Sep 21, 2022, 11:02 AM UTC (5edc1a4)">Diff</a>