### PR TITLE
Allow security metadata on Forms - closes #292

### DIFF
--- a/index.html
+++ b/index.html
@@ -753,17 +753,6 @@
         <p><span class="rfc2119-assertion" id="common-constraints-security-3">
             A Thing MAY implement multiple security schemes.</span>
         </p>
-        <p><span class="rfc2119-assertion" id="common-constraints-security-4">
-            Security schemes MUST be applied using the top level <code>security</code>
-            member of a
-            <a href="https://w3c.github.io/wot-thing-description/#thing">Thing</a>.</span>
-        </p>
-        <p><span class="rfc2119-assertion" id="common-constraints-security-5">
-            Security schemes
-            MUST NOT be applied to individual
-            <a href="https://w3c.github.io/wot-thing-description/#form"></a><code>
-                Form</code>s.</span>
-        </p>
     </section>
 
     <!-- Discovery -->


### PR DESCRIPTION
This PR proposes removing two assertions regarding where security metadata is allowed.

Closes #292.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/293.html" title="Last updated on Sep 21, 2022, 4:37 PM UTC (f83d835)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/293/5912319...benfrancis:f83d835.html" title="Last updated on Sep 21, 2022, 4:37 PM UTC (f83d835)">Diff</a>