### PR TITLE
fixing subprotocol id

### DIFF
--- a/index.html
+++ b/index.html
@@ -3134,7 +3134,7 @@
                 member is <code>http</code> or <code>https</code>
               </li>
               <li>Its <code>subprotocol</code> member has a value of
-                <code>"sse"</code>
+                <code>"webhook"</code>
               </li>
             </ul>
           </div>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/pull/301.html" title="Last updated on Oct 6, 2022, 9:47 AM UTC (947075c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/301/4d7d819...947075c.html" title="Last updated on Oct 6, 2022, 9:47 AM UTC (947075c)">Diff</a>