### PR TITLE
Remove unused security schemes

### DIFF
--- a/index.html
+++ b/index.html
@@ -727,16 +727,6 @@
               </a>
             </li>
             <li>
-              <a href="https://w3c.github.io/wot-thing-description/#digestsecurityscheme">
-                <code>DigestSecurityScheme</code>
-              </a>
-            </li>
-            <li>
-              <a href="https://w3c.github.io/wot-thing-description/#bearersecurityscheme">
-                <code>BearerSecurityScheme</code>
-              </a>
-            </li>
-            <li>
               <a href="https://w3c.github.io/wot-thing-description/#oauth2securityscheme">
                 <code>OAuth2SecurityScheme</code>
               </a>
@@ -746,11 +736,7 @@
         <p><span class="rfc2119-assertion" id="common-constraints-security-2">
             Conformant Consumers MUST support all of these security schemes.</span>
         </p>
-        <p class="ednote">
-          The list of security schemes to include is
-          still <a href="https://github.com/w3c/wot-profile/issues/6">under
-            discussion</a>.
-        </p>
+	    
         <p><span class="rfc2119-assertion" id="common-constraints-security-3">
             A Thing MAY implement multiple security schemes.</span>
         </p>


### PR DESCRIPTION
Reducing the list of security schemes and select the most widely used.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/pull/305.html" title="Last updated on Oct 19, 2022, 10:21 AM UTC (5288d1a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/305/7ba7a18...5288d1a.html" title="Last updated on Oct 19, 2022, 10:21 AM UTC (5288d1a)">Diff</a>