### PR TITLE
Allow auto security scheme for other permitted security schemes

### DIFF
--- a/index.html
+++ b/index.html
@@ -746,6 +746,13 @@
         <p><span class="rfc2119-assertion" id="common-constraints-security-3">
             A Thing MAY implement multiple security schemes.</span>
         </p>
+
+        <p><span class="rfc2119-assertion" id="common-constraints-security-auto">
+           The 
+           <a href="https://w3c.github.io/wot-thing-description/#autosecurityscheme"><code>AutoSecurityScheme</code></a>
+           MAY also be used, but only if negotation results in a security configuration
+           consistent with one of the <a href="#common-constraints-security-1">other permitted schemes</a>.</span>
+        </p>
         
         <p><span class="rfc2119-assertion" id="common-constraints-security-6">
           Conformant Consumers MUST support security bootstrapping for all 


### PR DESCRIPTION
Resolves https://github.com/w3c/wot-profile/issues/313

1. Rather than simply adding "auto" to the list of supported schemes, which would have opened up negotiation of schemes NOT on the permitted list, I added an additional assertion that allows "auto" (and therefore security negotiation) but says only configurations consistent with the other permitted schemes is allowed
2. I'm not sure what the intent of assertion common-constraints-security-6 is.  
      - If it is for Discovery, then it overlaps with common-constraints-security-7 and is redundant.
      - If is not, and the intent is to allow security bootstrapping for other affordances, then "auto" should be used in the TD to indicate this.
      - Either way, I think it should be removed...

I will hold this PR in "draft" state until we resolve point 2.
