### PR TITLE
Converting from ednote to note

### DIFF
--- a/index.html
+++ b/index.html
@@ -1407,13 +1407,13 @@
             HTTP/1.1 204 No Content
           </pre>
         </section>
-        <section class="ednote">
+        <section class="note">
           <p>
-            The <code>readmultipleproperties</code> operation is currently excluded due to
+            The <code>readmultipleproperties</code> operation is  excluded due to
             the complexities of the request payload format and because it
             doesn't add much functionality over <code>readproperty</code> and
             <code>readallproperties</code>.
-            <code>writeallproperties</code> is currently excluded because it
+            <code>writeallproperties</code> is excluded because it
             is just a special case of <code>writemultipleproperties</code>.
           </p>
         </section>


### PR DESCRIPTION
Editor's notes are typically only in drafts.

The slightly modified text can go into the final spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/pull/318.html" title="Last updated on Nov 9, 2022, 11:15 AM UTC (25ebb55)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/318/f041378...25ebb55.html" title="Last updated on Nov 9, 2022, 11:15 AM UTC (25ebb55)">Diff</a>