### PR TITLE
Removing mention of plugfest experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,10 +149,7 @@
       </li>
       <li>In addition, it defines a <strong><a href="#http-basic-profile">HTTP Basic
             Profile</a></strong> of the Thing Description, which
-        contains protocol binding rules for HTTP. The HTTP Basic
-          Profile formalizes the results of several PlugFests
-        that were conducted by the WoT Interest Group and of
-        tests that were conducted as part of the development.
+        contains protocol binding rules for HTTP.
         <p>The <em>normative</em> HTTP Basic Profile is complemented by two 
           <em>informative profiles for events</em>: The <a href=#sec-http-sse-profile>HTTP SSE Profile</a> 
           and the <a href="#sec-http-webhook-profile">HTTP Webhook Profile</a>.
@@ -272,11 +269,7 @@
       <p>
         The WoT HTTP Basic Profile can be used by green field
         deployments and gives guidance to new implementers of
-        the WoT specifications. It has already demonstrated in
-        brown-field scenarios in the Plugfests, where existing
-        devices that already existed as products, prototypes or
-        demonstrators, were described with Thing Descriptions
-        that are constrained to the HTTP Basic Profile.
+        the WoT specifications.
       </p>
     </section>
 
@@ -336,12 +329,6 @@
         These de-facto agreements select a common subset of the
         <a>WoT Thing Description</a>, based on
         proven interoperability among manufacturers.
-      </p>
-      <p>
-        The aim of this specification is to formalize these
-        agreements by defining a set of <strong>HTTP
-          Profiles</strong> based on the choices that were made by
-        the implementers of Plugfest devices.
       </p>
       <p>
         <span class="rfc2119-assertion" id="profile-why-a-basic-profile-1-x">


### PR DESCRIPTION
As discussed in many calls, there is no evidence of the current profile being used in plugfests prior to 2022-09. I find this text misleading since no one did async actions, SSE events or Webhook, problem details in plugfests as far as I know. This also gives the wrong impression that we only did HTTP in the plugfests.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/pull/321.html" title="Last updated on Nov 9, 2022, 5:07 PM UTC (2757b70)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/321/f06e542...2757b70.html" title="Last updated on Nov 9, 2022, 5:07 PM UTC (2757b70)">Diff</a>