### PR TITLE
Prepare 2-WD Release (phase 2)

### DIFF
--- a/publication/2-wd/Overview.html
+++ b/publication/2-wd/Overview.html
@@ -264,7 +264,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 <link rel="stylesheet" href=
 "https://www.w3.org/StyleSheets/TR/2021/W3C-WD">
 </head>
-<body class="h-entry toc-inline">
+<body class="h-entry">
 <div class="head">
 <p class="logos"><a class="logo" href=
 "https://www.w3.org/"><img crossorigin="" alt="W3C" height="48"
@@ -1131,10 +1131,10 @@ aria-haspopup="dialog" data-dfn-type="dfn">WoT Interface</dfn>, and
 <dfn class="lint-ignore" id="dfn-wot-runtime" tabindex="0"
 aria-haspopup="dialog" data-dfn-type="dfn">WoT Runtime</dfn> are
 defined in <a href=
-"https://www.w3.org/TR/wot-architecture/#terminology">Section 3</a>
-of the WoT Architecture specification [<cite><a class="bibref"
-data-link-type="biblio" href="#bib-wot-architecture" title=
-"Web of Things (WoT) Architecture">WOT-ARCHITECTURE</a></cite>].</p>
+"https://www.w3.org/TR/wot-architecture11/#terminology">Section
+3</a> of the WoT Architecture specification [<cite><a class=
+"bibref" data-link-type="biblio" href="#bib-wot-architecture"
+title="Web of Things (WoT) Architecture">WOT-ARCHITECTURE</a></cite>].</p>
 <p>For convenience of the reader, we use the terms <em>keyword</em>
 and <em>field</em> for the linguistic notion <em>vocabulary
 term</em> as defined in the <em>Thing Description</em>
@@ -1305,15 +1305,15 @@ Profiling Mechanism</h2>
 "Permalink for Section 5."></a></div>
 <p><span class="rfc2119-assertion" id="profiling-mechanism-1">In
 order to conform with a profile, a <a href=
-"https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+"https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
 <em class="rfc2119">MUST</em> conform with all the normative
 statements in the profile's specification.</span></p>
 <p><span class="rfc2119-assertion" id="profiling-mechanism-2">In
 order to denote that a given <a href=
-"https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+"https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
 conforms to one or more profiles, its Thing Description <em class=
 "rfc2119">MUST</em> include a <a href=
-"https://w3c.github.io/wot-thing-description/#thing"><code>profile</code></a>
+"https://www.w3.org/TR/wot-thing-description11/#thing"><code>profile</code></a>
 member [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-wot-thing-description11" title=
 "Web of Things (WoT) Thing Description 1.1">wot-thing-description11</a></cite>].</span>
@@ -1457,20 +1457,20 @@ when applied to a time denotes a UTC offset of 00:00.</p>
 aria-label="Permalink for Section 6.4"></a></div>
 <div class="rfc2119-assertion" id="common-constraints-security-1">
 <p>Below is a list of <a href=
-"https://w3c.github.io/wot-thing-description/#sec-security-vocabulary-definition">
+"https://www.w3.org/TR/wot-thing-description11/#sec-security-vocabulary-definition">
 security schemes</a> [<cite><a class="bibref" data-link-type=
 "biblio" href="#bib-wot-thing-description" title=
 "Web of Things (WoT) Thing Description">wot-thing-description</a></cite>]
 which conformant Web Things <em class="rfc2119">MAY</em> use:</p>
 <ul>
 <li><a href=
-"https://w3c.github.io/wot-thing-description/#nosecurityscheme"><code>
+"https://www.w3.org/TR/wot-thing-description11/#nosecurityscheme"><code>
 NoSecurityScheme</code></a></li>
 <li><a href=
-"https://w3c.github.io/wot-thing-description/#basicsecurityscheme"><code>
-BasicSecurityScheme</code></a></li>
+"https://www.w3.org/TR/wot-thing-description11/#basicsecurityscheme">
+<code>BasicSecurityScheme</code></a></li>
 <li><a href=
-"https://w3c.github.io/wot-thing-description/#oauth2securityscheme">
+"https://www.w3.org/TR/wot-thing-description11/#oauth2securityscheme">
 <code>OAuth2SecurityScheme</code> with the <code>code</code> or
 <code>client</code> flow.</a></li>
 </ul>
@@ -1486,7 +1486,7 @@ schemes.</span></p>
 "common-constraints-security-6">Conformant Consumers <em class=
 "rfc2119">MUST</em> support security bootstrapping for all
 implemented security schemes, as defined in <a href=
-"https://w3c.github.io/wot-discovery/#exploration-secboot">Security
+"https://www.w3.org/TR/wot-discovery/#exploration-secboot">Security
 Bootstrapping</a> in the WoT Discovery [<cite><a class="bibref"
 data-link-type="biblio" href="#bib-wot-discovery" title=
 "Web of Things (WoT) Discovery">wot-discovery</a></cite>]
@@ -1496,7 +1496,7 @@ specification.</span></p>
 authentication in order to retrieve their Thing Description
 <em class="rfc2119">MUST</em> implement security bootstrapping, as
 defined in <a href=
-"https://w3c.github.io/wot-discovery/#exploration-secboot">Security
+"https://www.w3.org/TR/wot-discovery/#exploration-secboot">Security
 Bootstrapping</a> in the WoT Discovery [<cite><a class="bibref"
 data-link-type="biblio" href="#bib-wot-discovery" title=
 "Web of Things (WoT) Discovery">wot-discovery</a></cite>]
@@ -1512,7 +1512,7 @@ Web Thing's Thing Description [<cite><a class="bibref"
 data-link-type="biblio" href="#bib-wot-thing-description" title=
 "Web of Things (WoT) Thing Description">wot-thing-description</a></cite>]
 <em class="rfc2119">MUST</em> be retrievable from a <a href=
-"https://w3c.github.io/wot-architecture/#dfn-wot-thing-description-server">
+"https://www.w3.org/TR/wot-architecture11/#dfn-wot-thing-description-server">
 Thing Description Server</a> [<cite><a class="bibref"
 data-link-type="biblio" href="#bib-wot-architecture11" title=
 "Web of Things (WoT) Architecture 1.1">wot-architecture11</a></cite>]
@@ -1520,7 +1520,7 @@ using an HTTP [<cite><a class="bibref" data-link-type="biblio"
 href="#bib-http11" title=
 "Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing">HTTP11</a></cite>]
 URL provided by a <a href=
-"https://w3c.github.io/wot-discovery/#introduction-mech">Direct
+"https://www.w3.org/TR/wot-discovery/#introduction-mech">Direct
 Introduction Mechanism</a> [<cite><a class="bibref" data-link-type=
 "biblio" href="#bib-wot-discovery" title=
 "Web of Things (WoT) Discovery">wot-discovery</a></cite>].</p>
@@ -1848,10 +1848,10 @@ Identifier</h3>
 aria-label="Permalink for Section 9.1"></a></div>
 <p><span class="rfc2119-assertion" id=
 "http-basic-profile-identifier-1">In order to denote that a given
-<a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web
+<a href="https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web
 Thing</a> conforms to the HTTP Basic Profile, its Thing Description
 <em class="rfc2119">MUST</em> have a <a href=
-"https://w3c.github.io/wot-thing-description/#thing"><code>profile</code></a>
+"https://www.w3.org/TR/wot-thing-description11/#thing"><code>profile</code></a>
 member [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-wot-thing-description" title=
 "Web of Things (WoT) Thing Description">wot-thing-description</a></cite>]
@@ -1866,9 +1866,9 @@ Protocol Binding</h3>
 aria-label="Permalink for Section 9.2"></a></div>
 <p>This section defines a protocol binding which describes how a
 <a href=
-"https://www.w3.org/TR/wot-architecture/#dfn-consumer">Consumer</a>
+"https://www.w3.org/TR/wot-architecture11/#dfn-consumer">Consumer</a>
 communicates with a <a href=
-"https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+"https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
 [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-wot-architecture11" title=
 "Web of Things (WoT) Architecture 1.1">wot-architecture11</a></cite>]
@@ -2020,10 +2020,10 @@ Properties</h4>
 <p>The URL of a <code>Property</code> resource to be used when
 reading the value of a property <em class="rfc2119">MUST</em> be
 obtained from a Thing Description by locating a <a href=
-"https://www.w3.org/TR/wot-thing-description/#form"><code>Form</code></a>
+"https://www.w3.org/TR/wot-thing-description11/#form"><code>Form</code></a>
 inside the corresponding <a href=
-"https://www.w3.org/TR/wot-thing-description/#propertyaffordance"><code>
-PropertyAffordance</code></a> for which:</p>
+"https://www.w3.org/TR/wot-thing-description11/#propertyaffordance">
+<code>PropertyAffordance</code></a> for which:</p>
 <ul>
 <li>After defaults have been applied, its <code>op</code> member
 contains the value <code>readproperty</code>.</li>
@@ -2096,10 +2096,10 @@ false</code></pre></div>
 <p>The URL of a <code>Property</code> resource to be used when
 writing the value of a property <em class="rfc2119">MUST</em> be
 obtained from a Thing Description by locating a <a href=
-"https://www.w3.org/TR/wot-thing-description/#form"><code>Form</code></a>
+"https://www.w3.org/TR/wot-thing-description11/#form"><code>Form</code></a>
 inside the corresponding <a href=
-"https://www.w3.org/TR/wot-thing-description/#propertyaffordance"><code>
-PropertyAffordance</code></a> for which:</p>
+"https://www.w3.org/TR/wot-thing-description11/#propertyaffordance">
+<code>PropertyAffordance</code></a> for which:</p>
 <ul>
 <li>After defaults have been applied, its <code>op</code> member
 contains the value <code>writeproperty</code></li>
@@ -2170,9 +2170,9 @@ aria-label="Permalink for Section 9.2.1.3"></a></div>
 reading the value of all properties at once <em class=
 "rfc2119">MUST</em> be obtained from a Thing Description by
 locating a <a href=
-"https://www.w3.org/TR/wot-thing-description/#form"><code>Form</code></a>
+"https://www.w3.org/TR/wot-thing-description11/#form"><code>Form</code></a>
 inside the top level <a href=
-"https://www.w3.org/TR/wot-thing-description/#form-serialization-json">
+"https://www.w3.org/TR/wot-thing-description11/#form-serialization-json">
 <code>forms</code></a> member for which:</p>
 <ul>
 <li>Its <code>op</code> member contains the value
@@ -2254,9 +2254,9 @@ aria-label="Permalink for Section 9.2.1.4"></a></div>
 writing the value of multiple properties at once <em class=
 "rfc2119">MUST</em> be obtained from a Thing Description by
 locating a <a href=
-"https://www.w3.org/TR/wot-thing-description/#form"><code>Form</code></a>
+"https://www.w3.org/TR/wot-thing-description11/#form"><code>Form</code></a>
 inside the top level <a href=
-"https://www.w3.org/TR/wot-thing-description/#form-serialization-json">
+"https://www.w3.org/TR/wot-thing-description11/#form-serialization-json">
 <code>forms</code></a> member for which:</p>
 <ul>
 <li>Its <code>op</code> member contains the value
@@ -2350,9 +2350,9 @@ is excluded because it is just a special case of
 <p>The URL of an <code>Action</code> resource to be used when
 invoking an action <em class="rfc2119">MUST</em> be obtained from a
 Thing Description by locating a <a href=
-"https://www.w3.org/TR/wot-thing-description/#form"><code>Form</code></a>
+"https://www.w3.org/TR/wot-thing-description11/#form"><code>Form</code></a>
 inside the corresponding <a href=
-"https://www.w3.org/TR/wot-thing-description/#actionaffordance"><code>
+"https://www.w3.org/TR/wot-thing-description11/#actionaffordance"><code>
 ActionAffordance</code></a> for which:</p>
 <ul>
 <li>After defaults have been applied, the value of its
@@ -2418,7 +2418,7 @@ Response</a></li>
 <p><span class="rfc2119-assertion" id=
 "http-basic-profile-protocol-binding-invokeaction-7">If the
 <code>synchronous</code> member of the <a href=
-"https://w3c.github.io/wot-thing-description/#actionaffordance"><code>
+"https://www.w3.org/TR/wot-thing-description11/#actionaffordance"><code>
 ActionAffordance</code></a> [<cite><a class="bibref"
 data-link-type="biblio" href="#bib-wot-thing-description11" title=
 "Web of Things (WoT) Thing Description 1.1">wot-thing-description11</a></cite>]
@@ -2428,7 +2428,7 @@ is set to <code>true</code> then the Web Thing <em class=
 <p><span class="rfc2119-assertion" id=
 "http-basic-profile-protocol-binding-invokeaction-8">If the
 <code>synchronous</code> member of the <a href=
-"https://w3c.github.io/wot-thing-description/#actionaffordance"><code>
+"https://www.w3.org/wot-thing-description11/#actionaffordance"><code>
 ActionAffordance</code></a> [<cite><a class="bibref"
 data-link-type="biblio" href="#bib-wot-thing-description11" title=
 "Web of Things (WoT) Thing Description 1.1">wot-thing-description11</a></cite>]
@@ -2439,7 +2439,7 @@ Response</a>.</span></p>
 <p><span class="rfc2119-assertion" id=
 "http-basic-profile-protocol-binding-invokeaction-9">If the
 <code>synchronous</code> member of the <a href=
-"https://w3c.github.io/wot-thing-description/#actionaffordance"><code>
+"https://www.w3.org/TR/wot-thing-description11/#actionaffordance"><code>
 ActionAffordance</code></a> [<cite><a class="bibref"
 data-link-type="biblio" href="#bib-wot-thing-description11" title=
 "Web of Things (WoT) Thing Description 1.1">wot-thing-description11</a></cite>]
@@ -2516,7 +2516,7 @@ string</code></a> (one of <code>pending</code>,
 <td>The output data, if any, of a completed action which <em class=
 "rfc2119">MUST</em> conform with the <code>output</code> data
 schema of the corresponding <a href=
-"https://www.w3.org/TR/wot-thing-description/#actionaffordance"><code>
+"https://www.w3.org/TR/wot-thing-description11/#actionaffordance"><code>
 ActionAffordance</code></a>.</td>
 <td>optional</td>
 <td>any type</td>
@@ -2857,9 +2857,9 @@ response with:</p>
 querying the status of all ongoing action requests <em class=
 "rfc2119">MUST</em> be obtained from a Thing Description by
 locating a <a href=
-"https://www.w3.org/TR/wot-thing-description/#form"><code>Form</code></a>
+"https://www.w3.org/TR/wot-thing-description11/#form"><code>Form</code></a>
 inside the top level <a href=
-"https://www.w3.org/TR/wot-thing-description/#form-serialization-json">
+"https://www.w3.org/TR/wot-thing-description11/#form-serialization-json">
 <code>forms</code></a> member for which:</p>
 <ul>
 <li>Its <code>op</code> member contains the value
@@ -3017,10 +3017,10 @@ Identifier</h3>
 aria-label="Permalink for Section 10.1"></a></div>
 <p><span class="rfc2119-assertion" id=
 "http-sse-profile-identifier-1">In order to denote that a given
-<a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web
+<a href="https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web
 Thing</a> conforms to the HTTP SSE Profile, its Thing Description
 <em class="rfc2119">MUST</em> have a <a href=
-"https://w3c.github.io/wot-thing-description/#thing"><code>profile</code></a>
+"https://www.w3.org/TR/wot-thing-description11/#thing"><code>profile</code></a>
 member [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-wot-thing-description" title=
 "Web of Things (WoT) Thing Description">wot-thing-description</a></cite>]
@@ -3035,9 +3035,9 @@ Protocol Binding</h3>
 aria-label="Permalink for Section 10.2"></a></div>
 <p>This section defines a protocol binding which describes how a
 <a href=
-"https://www.w3.org/TR/wot-architecture/#dfn-consumer">Consumer</a>
+"https://www.w3.org/TR/wot-architecture11/#dfn-consumer">Consumer</a>
 communicates with a <a href=
-"https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+"https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
 [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-wot-architecture11" title=
 "Web of Things (WoT) Architecture 1.1">wot-architecture11</a></cite>]
@@ -3226,10 +3226,10 @@ Properties</h4>
 <p>The URL of a <code>Property</code> resource to be used when
 observing the value of a property <em class="rfc2119">MUST</em> be
 obtained from a Thing Description by locating a <a href=
-"https://www.w3.org/TR/wot-thing-description/#form"><code>Form</code></a>
+"https://www.w3.org/TR/wot-thing-description11/#form"><code>Form</code></a>
 inside the corresponding <a href=
-"https://www.w3.org/TR/wot-thing-description/#propertyaffordance"><code>
-PropertyAffordance</code></a> for which:</p>
+"https://www.w3.org/TR/wot-thing-description11/#propertyaffordance">
+<code>PropertyAffordance</code></a> for which:</p>
 <ul>
 <li>Its <code>op</code> member contains the value
 <code>observeproperty</code></li>
@@ -3426,9 +3426,9 @@ data-link-type="biblio" href="#bib-eventsource" title=
 changes to all properties of a Web Thing <em class=
 "rfc2119">MUST</em> be obtained from a Thing Description by
 locating a <a href=
-"https://www.w3.org/TR/wot-thing-description/#form"><code>Form</code></a>
+"https://www.w3.org/TR/wot-thing-description11/#form"><code>Form</code></a>
 inside the top level <a href=
-"https://www.w3.org/TR/wot-thing-description/#form-serialization-json">
+"https://www.w3.org/TR/wot-thing-description11/#form-serialization-json">
 <code>forms</code></a> member of a Thing Description for which:</p>
 <ul>
 <li>Its <code>op</code> member contains the value
@@ -3650,9 +3650,9 @@ programming language may be used to consume an event stream.</p>
 <p>The URL of an <code>Event</code> resource to be used when
 subscribing to an event <em class="rfc2119">MUST</em> be obtained
 from a Thing Description by locating a <a href=
-"https://www.w3.org/TR/wot-thing-description/#form"><code>Form</code></a>
+"https://www.w3.org/TR/wot-thing-description11/#form"><code>Form</code></a>
 inside the corresponding <a href=
-"https://www.w3.org/TR/wot-thing-description/#eventaffordance"><code>
+"https://www.w3.org/TR/wot-thing-description11/#eventaffordance"><code>
 EventAffordance</code></a> for which:</p>
 <ul>
 <li>After defaults have been applied, its <code>op</code> member
@@ -3854,9 +3854,9 @@ aria-label="Permalink for Section 10.2.2.3"></a></div>
 <p>The URL of an events resource to be used when subscribing to all
 events emitted by a Web Thing <em class="rfc2119">MUST</em> be
 obtained from a Thing Description by locating a <a href=
-"https://www.w3.org/TR/wot-thing-description/#form"><code>Form</code></a>
+"https://www.w3.org/TR/wot-thing-description11/#form"><code>Form</code></a>
 inside the top level <a href=
-"https://www.w3.org/TR/wot-thing-description/#form-serialization-json">
+"https://www.w3.org/TR/wot-thing-description11/#form-serialization-json">
 <code>forms</code></a> member of a Thing Description for which:</p>
 <ul>
 <li>Its <code>op</code> member contains the value
@@ -4242,10 +4242,10 @@ Identifier</h3>
 aria-label="Permalink for Section 11.2"></a></div>
 <p><span class="rfc2119-assertion" id="http-webhook-profile-1">In
 order to denote that a given <a href=
-"https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+"https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
 conforms to the HTTP Webhook Profile, its Thing Description
 <em class="rfc2119">MUST</em> have a <a href=
-"https://w3c.github.io/wot-thing-description/#thing"><code>profile</code></a>
+"https://www.w3.org/TR/wot-thing-description11/#thing"><code>profile</code></a>
 member [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-wot-thing-description" title=
 "Web of Things (WoT) Thing Description">wot-thing-description</a></cite>]
@@ -4286,9 +4286,9 @@ Protocol Binding</h3>
 aria-label="Permalink for Section 11.4"></a></div>
 <p>This section defines a protocol binding which describes how a
 <a href=
-"https://www.w3.org/TR/wot-architecture/#dfn-consumer">Consumer</a>
+"https://www.w3.org/TR/wot-architecture11/#dfn-consumer">Consumer</a>
 and a <a href=
-"https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+"https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
 communicate using Webhook Events.</p>
 <p><span class="rfc2119-assertion" id=
 "http-webhook-profile-protocol-binding-1">A Consumer or Web Thing
@@ -4313,9 +4313,9 @@ Operations</h4>
 <p>The URL of an <code>Event</code> resource to be used when
 subscribing to an event <em class="rfc2119">MUST</em> be obtained
 from a Thing Description by locating a <a href=
-"https://www.w3.org/TR/wot-thing-description/#form"><code>Form</code></a>
+"https://www.w3.org/TR/wot-thing-description11/#form"><code>Form</code></a>
 inside the corresponding <a href=
-"https://www.w3.org/TR/wot-thing-description/#eventaffordance"><code>
+"https://www.w3.org/TR/wot-thing-description11/#eventaffordance"><code>
 EventAffordance</code></a> for which:</p>
 <ul>
 <li>After defaults have been applied, its <code>op</code> member
@@ -4449,9 +4449,9 @@ aria-label="Permalink for Section 11.4.1.3"></a></div>
 subscribing to all events emitted by a Web Thing <em class=
 "rfc2119">MUST</em> be obtained from a Thing Description by
 locating a <a href=
-"https://www.w3.org/TR/wot-thing-description/#form"><code>Form</code></a>
+"https://www.w3.org/TR/wot-thing-description11/#form"><code>Form</code></a>
 inside the top level <a href=
-"https://www.w3.org/TR/wot-thing-description/#form-serialization-json">
+"https://www.w3.org/TR/wot-thing-description11/#form-serialization-json">
 <code>forms</code></a> member of a Thing Description for which:</p>
 <ul>
 <li>Its <code>op</code> member contains the value
@@ -4534,7 +4534,7 @@ to the Consumer with:</p>
 an event occurs, the Web Thing <em class="rfc2119">MUST</em> send
 event data to the Consumer using the event payload format defined
 in section <a href=
-"sec-http-webhook-profile-message-format">Message
+"#sec-http-webhook-profile-message-format">Message
 Format</a>.</span></p>
 <p><span class="rfc2119-assertion" id=
 "http-webhook-profile-protocol-binding-subscribeallevents-7">If the
@@ -4649,9 +4649,9 @@ Privacy Considerations</h2>
 <p><span class="rfc2119-assertion" id=
 "privacy-considerations-1">The privacy considerations of the
 <a href=
-"https://w3c.github.io/wot-architecture/#sec-privacy-considerations">
+"https://www.w3.org/TR/wot-architecture11/#sec-privacy-considerations">
 WoT Architecture</a> and <a href=
-"https://w3c.github.io/wot-thing-description/#sec-privacy-consideration">
+"https://www.w3.org/TR/wot-thing-description11/#sec-privacy-consideration">
 WoT Thing Description</a> <em class="rfc2119">MUST</em> be adopted
 by compliant implementations.</span></p>
 </section>
@@ -4664,16 +4664,16 @@ Security Considerations</h2>
 <p><span class="rfc2119-assertion" id=
 "security-considerations-1">The security considerations of the
 <a href=
-"https://w3c.github.io/wot-architecture/#sec-security-consideration">
+"https://www.w3.org/TR/wot-architecture11/#sec-security-consideration">
 WoT Architecture</a> and <a href=
-"https://w3c.github.io/wot-thing-description/#sec-security-considerations">
+"https://www.w3.org/TR/wot-thing-description11/#sec-security-considerations">
 WoT Thing Description</a> <em class="rfc2119">MUST</em> be adopted
 by compliant implementations.</span></p>
 <div class="note" role="note" id="issue-container-generatedID-18">
 <div role="heading" class="note-title marker" id="h-note-15"
 aria-level="3"><span>Note</span></div>
 <p class="">Please see <a href=
-"https://w3c.github.io/wot-security-best-practices/">WoT Security
+"https://www.w3.org/TR/wot-security-best-practices/">WoT Security
 Best Practices</a> for implementation advice.</p>
 </div>
 </section>

--- a/publication/2-wd/index.html
+++ b/publication/2-wd/index.html
@@ -459,7 +459,7 @@
       <dfn id="dfn-vocab-term" class="lint-ignore">Vocabulary Term</dfn>,
       <dfn class="lint-ignore">WoT Interface</dfn>, and
       <dfn class="lint-ignore">WoT Runtime</dfn>
-      are defined in <a href="https://www.w3.org/TR/wot-architecture/#terminology">Section 3</a>
+      are defined in <a href="https://www.w3.org/TR/wot-architecture11/#terminology">Section 3</a>
       of the WoT Architecture specification [[?WOT-ARCHITECTURE]].
 
     <p>
@@ -599,7 +599,7 @@
     <p>
       <span class="rfc2119-assertion" id="profiling-mechanism-1">
         In order to conform with a profile, a
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
         MUST conform with all the normative statements in the profile's
         specification.
       </span>
@@ -607,9 +607,9 @@
     <p>
       <span class="rfc2119-assertion" id="profiling-mechanism-2">
         In order to denote that a given
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
         conforms to one or more profiles, its Thing Description MUST include a
-        <a href="https://w3c.github.io/wot-thing-description/#thing">
+        <a href="https://www.w3.org/TR/wot-thing-description11/#thing">
           <code>profile</code></a> member [[wot-thing-description11]].
       </span>
       <span class="rfc2119-assertion" id="profiling-mechanism-3">
@@ -727,23 +727,23 @@
         <div class="rfc2119-assertion" id="common-constraints-security-1">
           <p>
             Below is a list of <a
-              href="https://w3c.github.io/wot-thing-description/#sec-security-vocabulary-definition">
+              href="https://www.w3.org/TR/wot-thing-description11/#sec-security-vocabulary-definition">
               security schemes</a> [[wot-thing-description]] which conformant Web
             Things MAY use:
           </p>
           <ul>
             <li>
-              <a href="https://w3c.github.io/wot-thing-description/#nosecurityscheme">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#nosecurityscheme">
                 <code>NoSecurityScheme</code>
               </a>
             </li>
             <li>
-              <a href="https://w3c.github.io/wot-thing-description/#basicsecurityscheme">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#basicsecurityscheme">
                 <code>BasicSecurityScheme</code>
               </a>
             </li>
             <li>
-              <a href="https://w3c.github.io/wot-thing-description/#oauth2securityscheme">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#oauth2securityscheme">
                 <code>OAuth2SecurityScheme</code> with the <code>code</code> or <code>client</code> flow.
               </a>
             </li>
@@ -760,7 +760,7 @@
         <p><span class="rfc2119-assertion" id="common-constraints-security-6">
           Conformant Consumers MUST support security bootstrapping for all 
           implemented security schemes, as defined in
-          <a href="https://w3c.github.io/wot-discovery/#exploration-secboot">Security Bootstrapping</a>
+          <a href="https://www.w3.org/TR/wot-discovery/#exploration-secboot">Security Bootstrapping</a>
           in the WoT Discovery [[wot-discovery]] specification.
         </span></p>
         
@@ -768,7 +768,7 @@
           Conformant Things which require authentication in order to retrieve 
           their Thing Description MUST implement security bootstrapping, as
           defined in 
-          <a href="https://w3c.github.io/wot-discovery/#exploration-secboot">Security Bootstrapping</a>
+          <a href="https://www.w3.org/TR/wot-discovery/#exploration-secboot">Security Bootstrapping</a>
           in the WoT Discovery [[wot-discovery]] specification.
         </span></p>
     </section>
@@ -779,10 +779,10 @@
       <p class="rfc2119-assertion" id="common-constraints-discovery-1">
         A Web Thing's Thing Description [[wot-thing-description]] MUST be 
         retrievable from a
-        <a href="https://w3c.github.io/wot-architecture/#dfn-wot-thing-description-server">
+        <a href="https://www.w3.org/TR/wot-architecture11/#dfn-wot-thing-description-server">
           Thing Description Server</a> [[wot-architecture11]] using an HTTP
         [[HTTP11]] URL provided by a
-        <a href="https://w3c.github.io/wot-discovery/#introduction-mech">
+        <a href="https://www.w3.org/TR/wot-discovery/#introduction-mech">
           Direct Introduction Mechanism</a> [[wot-discovery]].
       </p>
     </section>
@@ -1093,9 +1093,9 @@
       <h2>Identifier</h2>
       <p><span class="rfc2119-assertion" id="http-basic-profile-identifier-1">
           In order to denote that a given
-          <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+          <a href="https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
           conforms to the HTTP Basic Profile, its Thing Description MUST have a
-          <a href="https://w3c.github.io/wot-thing-description/#thing">
+          <a href="https://www.w3.org/TR/wot-thing-description11/#thing">
             <code>profile</code></a> member [[wot-thing-description]] with a value
           of <code>https://www.w3.org/2022/wot/profile/http-basic/v1</code>.</span>
       </p>
@@ -1106,9 +1106,9 @@
       <h3>Protocol Binding</h3>
       <p>
         This section defines a protocol binding which describes how a
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-consumer">Consumer</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#dfn-consumer">Consumer</a>
         communicates with a
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
         [[wot-architecture11]] using JSON [[JSON]] payloads over
         the HTTP [[HTTP11]] protocol.
       </p>
@@ -1206,9 +1206,9 @@
               The URL of a <code>Property</code> resource to be used when reading
               the value of a property MUST be obtained from a Thing Description by
               locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the corresponding
-              <a href="https://www.w3.org/TR/wot-thing-description/#propertyaffordance">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#propertyaffordance">
                 <code>PropertyAffordance</code></a>
               for which:
             </p>
@@ -1273,9 +1273,9 @@
               The URL of a <code>Property</code> resource to be used when writing
               the value of a property MUST be obtained from a Thing Description by
               locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the corresponding
-              <a href="https://www.w3.org/TR/wot-thing-description/#propertyaffordance">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#propertyaffordance">
                 <code>PropertyAffordance</code></a>
               for which:
             </p>
@@ -1337,9 +1337,9 @@
               The URL of a <code>Properties</code> resource to be used when
               reading the value of all properties at once MUST be obtained from a
               Thing Description by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the top level
-              <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form-serialization-json">
                 <code>forms</code></a> member
               for which:
             </p>
@@ -1411,9 +1411,9 @@
               The URL of a <code>Properties</code> resource to be used when
               writing the value of multiple properties at once MUST be obtained
               from a Thing Description by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the top level
-              <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form-serialization-json">
                 <code>forms</code></a> member
               for which:
             </p>
@@ -1493,9 +1493,9 @@
             <p>
               The URL of an <code>Action</code> resource to be used when invoking
               an action MUST be obtained from a Thing Description by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the corresponding
-              <a href="https://www.w3.org/TR/wot-thing-description/#actionaffordance">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance">
                 <code>ActionAffordance</code></a>
               for which:
             </p>
@@ -1562,7 +1562,7 @@
             <span class="rfc2119-assertion" 
             id="http-basic-profile-protocol-binding-invokeaction-7">
               If the <code>synchronous</code> member of the 
-              <a href="https://w3c.github.io/wot-thing-description/#actionaffordance"><code>ActionAffordance</code></a>
+              <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance"><code>ActionAffordance</code></a>
               [[wot-thing-description11]] is set to <code>true</code> then the Web 
               Thing MUST respond with a
               <a href="#sync-action-response">Synchronous Action Response</a>.
@@ -1572,7 +1572,7 @@
             <span class="rfc2119-assertion" 
             id="http-basic-profile-protocol-binding-invokeaction-8">
               If the <code>synchronous</code> member of the 
-              <a href="https://w3c.github.io/wot-thing-description/#actionaffordance"><code>ActionAffordance</code></a>
+              <a href="https://www.w3.org/wot-thing-description11/#actionaffordance"><code>ActionAffordance</code></a>
               [[wot-thing-description11]] is set to <code>false</code> then the Web 
               Thing MUST respond with an
               <a href="#async-action-response">Asynchronous Action Response</a>.
@@ -1582,7 +1582,7 @@
             <span class="rfc2119-assertion" 
             id="http-basic-profile-protocol-binding-invokeaction-9">
               If the <code>synchronous</code> member of the 
-              <a href="https://w3c.github.io/wot-thing-description/#actionaffordance"><code>ActionAffordance</code></a>
+              <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance"><code>ActionAffordance</code></a>
               [[wot-thing-description11]] is <code>undefined</code> then the Web 
               Thing MAY respond with either a 
               <a href="#sync-action-response">Synchronous Action Response</a> or
@@ -1650,7 +1650,7 @@
                     The output data, if any, of a completed action which
                     MUST conform with the <code>output</code> data schema of the
                     corresponding
-                    <a href="https://www.w3.org/TR/wot-thing-description/#actionaffordance">
+                    <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance">
                       <code>ActionAffordance</code></a>.
                   </td>
                   <td>optional</td>
@@ -1945,9 +1945,9 @@
               The URL of an <code>Actions</code> resource to be used when
               querying the status of all ongoing action requests MUST be obtained
               from a Thing Description by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the top level
-              <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form-serialization-json">
                 <code>forms</code></a> member
               for which:
             </p>
@@ -2085,9 +2085,9 @@
       <h2>Identifier</h2>
       <p><span class="rfc2119-assertion" id="http-sse-profile-identifier-1">
           In order to denote that a given
-          <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+          <a href="https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
           conforms to the HTTP SSE Profile, its Thing Description MUST have a
-          <a href="https://w3c.github.io/wot-thing-description/#thing">
+          <a href="https://www.w3.org/TR/wot-thing-description11/#thing">
             <code>profile</code></a> member [[wot-thing-description]] with a value
           of <code>https://www.w3.org/2022/wot/profile/http-sse/v1</code>.</span>
       </p>
@@ -2096,9 +2096,9 @@
       <h2>Protocol Binding</h2>
       <p>
         This section defines a protocol binding which describes how a
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-consumer">Consumer</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#dfn-consumer">Consumer</a>
         communicates with a
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
         [[wot-architecture11]] using Server-Sent Events [[EVENTSOURCE]].
       </p>
       <p>
@@ -2222,9 +2222,9 @@
               The URL of a <code>Property</code> resource to be used when
               observing the value of a property MUST be obtained from a Thing
               Description by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the corresponding
-              <a href="https://www.w3.org/TR/wot-thing-description/#propertyaffordance">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#propertyaffordance">
                 <code>PropertyAffordance</code></a>
               for which:
             </p>
@@ -2383,9 +2383,9 @@
               The URL of a properties resource to be used when observing
               changes to all properties of a Web Thing MUST be obtained from a
               Thing Description by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the top level
-              <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json"><code>forms</code></a>
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form-serialization-json"><code>forms</code></a>
               member of a Thing Description for which:
             </p>
             <ul>
@@ -2558,9 +2558,9 @@
               The URL of an <code>Event</code> resource to be used when
               subscribing to an event MUST be obtained from a Thing Description
               by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the corresponding
-              <a href="https://www.w3.org/TR/wot-thing-description/#eventaffordance">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#eventaffordance">
                 <code>EventAffordance</code></a> for which:
             </p>
             <ul>
@@ -2715,9 +2715,9 @@
               The URL of an events resource to be used when subscribing to all
               events emitted by a Web Thing MUST be obtained from a Thing
               Description by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the top level
-              <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json"><code>forms</code></a>
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form-serialization-json"><code>forms</code></a>
               member of a Thing Description for which:
             </p>
             <ul>
@@ -3008,9 +3008,9 @@
       <h2>Identifier</h2>
       <p><span class="rfc2119-assertion" id="http-webhook-profile-1">
           In order to denote that a given
-          <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+          <a href="https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
           conforms to the HTTP Webhook Profile, its Thing Description MUST have a
-          <a href="https://w3c.github.io/wot-thing-description/#thing">
+          <a href="https://www.w3.org/TR/wot-thing-description11/#thing">
             <code>profile</code></a> member [[wot-thing-description]] with a value
           of <code>https://www.w3.org/2022/wot/profile/http-webhook/v1</code>.</span>
       </p>
@@ -3036,9 +3036,9 @@
       <h2>Protocol Binding</h2>
       <p>
         This section defines a protocol binding which describes how a
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-consumer">Consumer</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#dfn-consumer">Consumer</a>
         and a
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
         communicate using Webhook Events.
       </p>
       <p>
@@ -3057,9 +3057,9 @@
               The URL of an <code>Event</code> resource to be used when
               subscribing to an event MUST be obtained from a Thing Description
               by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the corresponding
-              <a href="https://www.w3.org/TR/wot-thing-description/#eventaffordance">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#eventaffordance">
                 <code>EventAffordance</code></a> for which:
             </p>
             <ul>
@@ -3186,9 +3186,9 @@
               The URL of an <code>Events</code> resource to be used when subscribing to all
               events emitted by a Web Thing MUST be obtained from a Thing
               Description by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the top level
-              <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json"><code>forms</code></a>
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form-serialization-json"><code>forms</code></a>
               member of a Thing Description for which:
             </p>
             <ul>
@@ -3271,7 +3271,7 @@
           <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-subscribeallevents-6">
               Whenever an event occurs, the Web Thing MUST send event data to the Consumer
               using the event payload format defined in section <a
-                href="sec-http-webhook-profile-message-format">Message Format</a>.</span>
+                href="#sec-http-webhook-profile-message-format">Message Format</a>.</span>
 
           <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-subscribeallevents-7">
               If the connection between the Web Thing and the Consumer drops,
@@ -3358,9 +3358,9 @@
     <h4>Privacy Considerations</h4>
     <p><span class="rfc2119-assertion" id="privacy-considerations-1">
         The privacy considerations of the
-        <a href="https://w3c.github.io/wot-architecture/#sec-privacy-considerations">WoT Architecture</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#sec-privacy-considerations">WoT Architecture</a>
         and
-        <a href="https://w3c.github.io/wot-thing-description/#sec-privacy-consideration">WoT Thing Description</a>
+        <a href="https://www.w3.org/TR/wot-thing-description11/#sec-privacy-consideration">WoT Thing Description</a>
         MUST be adopted by compliant implementations.</span>
     </p>
   </section>
@@ -3369,13 +3369,13 @@
     <h4>Security Considerations</h4>
     <p><span class="rfc2119-assertion" id="security-considerations-1">
         The security considerations of the
-        <a href="https://w3c.github.io/wot-architecture/#sec-security-consideration">WoT Architecture</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#sec-security-consideration">WoT Architecture</a>
         and
-        <a href="https://w3c.github.io/wot-thing-description/#sec-security-considerations">WoT Thing Description</a>
+        <a href="https://www.w3.org/TR/wot-thing-description11/#sec-security-considerations">WoT Thing Description</a>
         MUST be adopted by compliant implementations.</span>
     </p>
     <p class="note">
-      Please see <a href="https://w3c.github.io/wot-security-best-practices/">
+      Please see <a href="https://www.w3.org/TR/wot-security-best-practices/">
         WoT Security Best Practices</a> for implementation advice.
     </p>
   </section>

--- a/publication/2-wd/static.html
+++ b/publication/2-wd/static.html
@@ -264,7 +264,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 }</script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-WD"></head>
 
-<body class="h-entry toc-inline"><div class="head">
+<body class="h-entry"><div class="head">
     <p class="logos"><a class="logo" href="https://www.w3.org/"><img crossorigin="" alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
   </a></p>
     <h1 id="title" class="title">Web of Things (WoT) Profile</h1> 
@@ -714,7 +714,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       <dfn id="dfn-vocab-term" class="lint-ignore" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Vocabulary Term</dfn>,
       <dfn class="lint-ignore" id="dfn-wot-interface" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">WoT Interface</dfn>, and
       <dfn class="lint-ignore" id="dfn-wot-runtime" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">WoT Runtime</dfn>
-      are defined in <a href="https://www.w3.org/TR/wot-architecture/#terminology">Section 3</a>
+      are defined in <a href="https://www.w3.org/TR/wot-architecture11/#terminology">Section 3</a>
       of the WoT Architecture specification [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">WOT-ARCHITECTURE</a></cite>].
 
     </p><p>
@@ -854,7 +854,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     <p>
       <span class="rfc2119-assertion" id="profiling-mechanism-1">
         In order to conform with a profile, a
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
         <em class="rfc2119">MUST</em> conform with all the normative statements in the profile's
         specification.
       </span>
@@ -862,9 +862,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     <p>
       <span class="rfc2119-assertion" id="profiling-mechanism-2">
         In order to denote that a given
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
         conforms to one or more profiles, its Thing Description <em class="rfc2119">MUST</em> include a
-        <a href="https://w3c.github.io/wot-thing-description/#thing">
+        <a href="https://www.w3.org/TR/wot-thing-description11/#thing">
           <code>profile</code></a> member [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-thing-description11" title="Web of Things (WoT) Thing Description 1.1">wot-thing-description11</a></cite>].
       </span>
       <span class="rfc2119-assertion" id="profiling-mechanism-3">
@@ -987,23 +987,23 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       
         <div class="rfc2119-assertion" id="common-constraints-security-1">
           <p>
-            Below is a list of <a href="https://w3c.github.io/wot-thing-description/#sec-security-vocabulary-definition">
+            Below is a list of <a href="https://www.w3.org/TR/wot-thing-description11/#sec-security-vocabulary-definition">
               security schemes</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-thing-description" title="Web of Things (WoT) Thing Description">wot-thing-description</a></cite>] which conformant Web
             Things <em class="rfc2119">MAY</em> use:
           </p>
           <ul>
             <li>
-              <a href="https://w3c.github.io/wot-thing-description/#nosecurityscheme">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#nosecurityscheme">
                 <code>NoSecurityScheme</code>
               </a>
             </li>
             <li>
-              <a href="https://w3c.github.io/wot-thing-description/#basicsecurityscheme">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#basicsecurityscheme">
                 <code>BasicSecurityScheme</code>
               </a>
             </li>
             <li>
-              <a href="https://w3c.github.io/wot-thing-description/#oauth2securityscheme">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#oauth2securityscheme">
                 <code>OAuth2SecurityScheme</code> with the <code>code</code> or <code>client</code> flow.
               </a>
             </li>
@@ -1020,7 +1020,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
         <p><span class="rfc2119-assertion" id="common-constraints-security-6">
           Conformant Consumers <em class="rfc2119">MUST</em> support security bootstrapping for all 
           implemented security schemes, as defined in
-          <a href="https://w3c.github.io/wot-discovery/#exploration-secboot">Security Bootstrapping</a>
+          <a href="https://www.w3.org/TR/wot-discovery/#exploration-secboot">Security Bootstrapping</a>
           in the WoT Discovery [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-discovery" title="Web of Things (WoT) Discovery">wot-discovery</a></cite>] specification.
         </span></p>
         
@@ -1028,7 +1028,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
           Conformant Things which require authentication in order to retrieve 
           their Thing Description <em class="rfc2119">MUST</em> implement security bootstrapping, as
           defined in 
-          <a href="https://w3c.github.io/wot-discovery/#exploration-secboot">Security Bootstrapping</a>
+          <a href="https://www.w3.org/TR/wot-discovery/#exploration-secboot">Security Bootstrapping</a>
           in the WoT Discovery [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-discovery" title="Web of Things (WoT) Discovery">wot-discovery</a></cite>] specification.
         </span></p>
     </section>
@@ -1039,10 +1039,10 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       <p class="rfc2119-assertion" id="common-constraints-discovery-1">
         A Web Thing's Thing Description [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-thing-description" title="Web of Things (WoT) Thing Description">wot-thing-description</a></cite>] <em class="rfc2119">MUST</em> be 
         retrievable from a
-        <a href="https://w3c.github.io/wot-architecture/#dfn-wot-thing-description-server">
+        <a href="https://www.w3.org/TR/wot-architecture11/#dfn-wot-thing-description-server">
           Thing Description Server</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture11" title="Web of Things (WoT) Architecture 1.1">wot-architecture11</a></cite>] using an HTTP
         [<cite><a class="bibref" data-link-type="biblio" href="#bib-http11" title="Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing">HTTP11</a></cite>] URL provided by a
-        <a href="https://w3c.github.io/wot-discovery/#introduction-mech">
+        <a href="https://www.w3.org/TR/wot-discovery/#introduction-mech">
           Direct Introduction Mechanism</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-discovery" title="Web of Things (WoT) Discovery">wot-discovery</a></cite>].
       </p>
     </section>
@@ -1352,9 +1352,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       
       <p><span class="rfc2119-assertion" id="http-basic-profile-identifier-1">
           In order to denote that a given
-          <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+          <a href="https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
           conforms to the HTTP Basic Profile, its Thing Description <em class="rfc2119">MUST</em> have a
-          <a href="https://w3c.github.io/wot-thing-description/#thing">
+          <a href="https://www.w3.org/TR/wot-thing-description11/#thing">
             <code>profile</code></a> member [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-thing-description" title="Web of Things (WoT) Thing Description">wot-thing-description</a></cite>] with a value
           of <code>https://www.w3.org/2022/wot/profile/http-basic/v1</code>.</span>
       </p>
@@ -1365,9 +1365,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       
       <p>
         This section defines a protocol binding which describes how a
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-consumer">Consumer</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#dfn-consumer">Consumer</a>
         communicates with a
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
         [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture11" title="Web of Things (WoT) Architecture 1.1">wot-architecture11</a></cite>] using JSON [<cite><a class="bibref" data-link-type="biblio" href="#bib-json" title="The JavaScript Object Notation (JSON) Data Interchange Format">JSON</a></cite>] payloads over
         the HTTP [<cite><a class="bibref" data-link-type="biblio" href="#bib-http11" title="Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing">HTTP11</a></cite>] protocol.
       </p>
@@ -1467,9 +1467,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               The URL of a <code>Property</code> resource to be used when reading
               the value of a property <em class="rfc2119">MUST</em> be obtained from a Thing Description by
               locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the corresponding
-              <a href="https://www.w3.org/TR/wot-thing-description/#propertyaffordance">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#propertyaffordance">
                 <code>PropertyAffordance</code></a>
               for which:
             </p>
@@ -1538,9 +1538,9 @@ false</code></pre>
               The URL of a <code>Property</code> resource to be used when writing
               the value of a property <em class="rfc2119">MUST</em> be obtained from a Thing Description by
               locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the corresponding
-              <a href="https://www.w3.org/TR/wot-thing-description/#propertyaffordance">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#propertyaffordance">
                 <code>PropertyAffordance</code></a>
               for which:
             </p>
@@ -1606,9 +1606,9 @@ Content-Type: application/json
               The URL of a <code>Properties</code> resource to be used when
               reading the value of all properties at once <em class="rfc2119">MUST</em> be obtained from a
               Thing Description by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the top level
-              <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form-serialization-json">
                 <code>forms</code></a> member
               for which:
             </p>
@@ -1684,9 +1684,9 @@ Content-Type: application/json
               The URL of a <code>Properties</code> resource to be used when
               writing the value of multiple properties at once <em class="rfc2119">MUST</em> be obtained
               from a Thing Description by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the top level
-              <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form-serialization-json">
                 <code>forms</code></a> member
               for which:
             </p>
@@ -1770,9 +1770,9 @@ Content-Type: application/json
             <p>
               The URL of an <code>Action</code> resource to be used when invoking
               an action <em class="rfc2119">MUST</em> be obtained from a Thing Description by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the corresponding
-              <a href="https://www.w3.org/TR/wot-thing-description/#actionaffordance">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance">
                 <code>ActionAffordance</code></a>
               for which:
             </p>
@@ -1840,7 +1840,7 @@ Accept: application/json
           <p>
             <span class="rfc2119-assertion" id="http-basic-profile-protocol-binding-invokeaction-7">
               If the <code>synchronous</code> member of the 
-              <a href="https://w3c.github.io/wot-thing-description/#actionaffordance"><code>ActionAffordance</code></a>
+              <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance"><code>ActionAffordance</code></a>
               [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-thing-description11" title="Web of Things (WoT) Thing Description 1.1">wot-thing-description11</a></cite>] is set to <code>true</code> then the Web 
               Thing <em class="rfc2119">MUST</em> respond with a
               <a href="#sync-action-response">Synchronous Action Response</a>.
@@ -1849,7 +1849,7 @@ Accept: application/json
           <p>
             <span class="rfc2119-assertion" id="http-basic-profile-protocol-binding-invokeaction-8">
               If the <code>synchronous</code> member of the 
-              <a href="https://w3c.github.io/wot-thing-description/#actionaffordance"><code>ActionAffordance</code></a>
+              <a href="https://www.w3.org/wot-thing-description11/#actionaffordance"><code>ActionAffordance</code></a>
               [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-thing-description11" title="Web of Things (WoT) Thing Description 1.1">wot-thing-description11</a></cite>] is set to <code>false</code> then the Web 
               Thing <em class="rfc2119">MUST</em> respond with an
               <a href="#async-action-response">Asynchronous Action Response</a>.
@@ -1858,7 +1858,7 @@ Accept: application/json
           <p>
             <span class="rfc2119-assertion" id="http-basic-profile-protocol-binding-invokeaction-9">
               If the <code>synchronous</code> member of the 
-              <a href="https://w3c.github.io/wot-thing-description/#actionaffordance"><code>ActionAffordance</code></a>
+              <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance"><code>ActionAffordance</code></a>
               [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-thing-description11" title="Web of Things (WoT) Thing Description 1.1">wot-thing-description11</a></cite>] is <code>undefined</code> then the Web 
               Thing <em class="rfc2119">MAY</em> respond with either a 
               <a href="#sync-action-response">Synchronous Action Response</a> or
@@ -1926,7 +1926,7 @@ Accept: application/json
                     The output data, if any, of a completed action which
                     <em class="rfc2119">MUST</em> conform with the <code>output</code> data schema of the
                     corresponding
-                    <a href="https://www.w3.org/TR/wot-thing-description/#actionaffordance">
+                    <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance">
                       <code>ActionAffordance</code></a>.
                   </td>
                   <td>optional</td>
@@ -2235,9 +2235,9 @@ Accept: application/json</code></pre>
               The URL of an <code>Actions</code> resource to be used when
               querying the status of all ongoing action requests <em class="rfc2119">MUST</em> be obtained
               from a Thing Description by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the top level
-              <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form-serialization-json">
                 <code>forms</code></a> member
               for which:
             </p>
@@ -2379,9 +2379,9 @@ Accept: application/json</code></pre>
       
       <p><span class="rfc2119-assertion" id="http-sse-profile-identifier-1">
           In order to denote that a given
-          <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+          <a href="https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
           conforms to the HTTP SSE Profile, its Thing Description <em class="rfc2119">MUST</em> have a
-          <a href="https://w3c.github.io/wot-thing-description/#thing">
+          <a href="https://www.w3.org/TR/wot-thing-description11/#thing">
             <code>profile</code></a> member [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-thing-description" title="Web of Things (WoT) Thing Description">wot-thing-description</a></cite>] with a value
           of <code>https://www.w3.org/2022/wot/profile/http-sse/v1</code>.</span>
       </p>
@@ -2390,9 +2390,9 @@ Accept: application/json</code></pre>
       
       <p>
         This section defines a protocol binding which describes how a
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-consumer">Consumer</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#dfn-consumer">Consumer</a>
         communicates with a
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
         [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture11" title="Web of Things (WoT) Architecture 1.1">wot-architecture11</a></cite>] using Server-Sent Events [<cite><a class="bibref" data-link-type="biblio" href="#bib-eventsource" title="Server-Sent Events">EVENTSOURCE</a></cite>].
       </p>
       <p>
@@ -2518,9 +2518,9 @@ Accept: application/json</code></pre>
               The URL of a <code>Property</code> resource to be used when
               observing the value of a property <em class="rfc2119">MUST</em> be obtained from a Thing
               Description by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the corresponding
-              <a href="https://www.w3.org/TR/wot-thing-description/#propertyaffordance">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#propertyaffordance">
                 <code>PropertyAffordance</code></a>
               for which:
             </p>
@@ -2689,9 +2689,9 @@ id: 2021-11-17T15:33:20.827Z\n\n</code></pre>
               The URL of a properties resource to be used when observing
               changes to all properties of a Web Thing <em class="rfc2119">MUST</em> be obtained from a
               Thing Description by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the top level
-              <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json"><code>forms</code></a>
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form-serialization-json"><code>forms</code></a>
               member of a Thing Description for which:
             </p>
             <ul>
@@ -2874,9 +2874,9 @@ id: 2021-11-17T15:33:20.827Z\n\n</code></pre>
               The URL of an <code>Event</code> resource to be used when
               subscribing to an event <em class="rfc2119">MUST</em> be obtained from a Thing Description
               by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the corresponding
-              <a href="https://www.w3.org/TR/wot-thing-description/#eventaffordance">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#eventaffordance">
                 <code>EventAffordance</code></a> for which:
             </p>
             <ul>
@@ -3041,9 +3041,9 @@ id: 2021-11-16T16:53:50.817Z\n\n</code></pre>
               The URL of an events resource to be used when subscribing to all
               events emitted by a Web Thing <em class="rfc2119">MUST</em> be obtained from a Thing
               Description by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the top level
-              <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json"><code>forms</code></a>
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form-serialization-json"><code>forms</code></a>
               member of a Thing Description for which:
             </p>
             <ul>
@@ -3345,9 +3345,9 @@ id: 2021-11-16T16:53:50.817Z\n\n</code></pre>
       
       <p><span class="rfc2119-assertion" id="http-webhook-profile-1">
           In order to denote that a given
-          <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+          <a href="https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
           conforms to the HTTP Webhook Profile, its Thing Description <em class="rfc2119">MUST</em> have a
-          <a href="https://w3c.github.io/wot-thing-description/#thing">
+          <a href="https://www.w3.org/TR/wot-thing-description11/#thing">
             <code>profile</code></a> member [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-thing-description" title="Web of Things (WoT) Thing Description">wot-thing-description</a></cite>] with a value
           of <code>https://www.w3.org/2022/wot/profile/http-webhook/v1</code>.</span>
       </p>
@@ -3373,9 +3373,9 @@ id: 2021-11-16T16:53:50.817Z\n\n</code></pre>
       
       <p>
         This section defines a protocol binding which describes how a
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-consumer">Consumer</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#dfn-consumer">Consumer</a>
         and a
-        <a href="https://www.w3.org/TR/wot-architecture/#dfn-thing">Web Thing</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#dfn-thing">Web Thing</a>
         communicate using Webhook Events.
       </p>
       <p>
@@ -3394,9 +3394,9 @@ id: 2021-11-16T16:53:50.817Z\n\n</code></pre>
               The URL of an <code>Event</code> resource to be used when
               subscribing to an event <em class="rfc2119">MUST</em> be obtained from a Thing Description
               by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the corresponding
-              <a href="https://www.w3.org/TR/wot-thing-description/#eventaffordance">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#eventaffordance">
                 <code>EventAffordance</code></a> for which:
             </p>
             <ul>
@@ -3528,9 +3528,9 @@ id: 2021-11-16T16:53:50.817Z\n\n</code></pre>
               The URL of an <code>Events</code> resource to be used when subscribing to all
               events emitted by a Web Thing <em class="rfc2119">MUST</em> be obtained from a Thing
               Description by locating a
-              <a href="https://www.w3.org/TR/wot-thing-description/#form">
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form">
                 <code>Form</code></a> inside the top level
-              <a href="https://www.w3.org/TR/wot-thing-description/#form-serialization-json"><code>forms</code></a>
+              <a href="https://www.w3.org/TR/wot-thing-description11/#form-serialization-json"><code>forms</code></a>
               member of a Thing Description for which:
             </p>
             <ul>
@@ -3616,7 +3616,7 @@ id: 2021-11-16T16:53:50.817Z\n\n</code></pre>
 
           <p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-subscribeallevents-6">
               Whenever an event occurs, the Web Thing <em class="rfc2119">MUST</em> send event data to the Consumer
-              using the event payload format defined in section <a href="sec-http-webhook-profile-message-format">Message Format</a>.</span>
+              using the event payload format defined in section <a href="#sec-http-webhook-profile-message-format">Message Format</a>.</span>
 
           </p><p><span class="rfc2119-assertion" id="http-webhook-profile-protocol-binding-subscribeallevents-7">
               If the connection between the Web Thing and the Consumer drops,
@@ -3705,9 +3705,9 @@ id: 2021-11-16T16:53:50.817Z\n\n</code></pre>
     
     <p><span class="rfc2119-assertion" id="privacy-considerations-1">
         The privacy considerations of the
-        <a href="https://w3c.github.io/wot-architecture/#sec-privacy-considerations">WoT Architecture</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#sec-privacy-considerations">WoT Architecture</a>
         and
-        <a href="https://w3c.github.io/wot-thing-description/#sec-privacy-consideration">WoT Thing Description</a>
+        <a href="https://www.w3.org/TR/wot-thing-description11/#sec-privacy-consideration">WoT Thing Description</a>
         <em class="rfc2119">MUST</em> be adopted by compliant implementations.</span>
     </p>
   </section>
@@ -3716,13 +3716,13 @@ id: 2021-11-16T16:53:50.817Z\n\n</code></pre>
     
     <p><span class="rfc2119-assertion" id="security-considerations-1">
         The security considerations of the
-        <a href="https://w3c.github.io/wot-architecture/#sec-security-consideration">WoT Architecture</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#sec-security-consideration">WoT Architecture</a>
         and
-        <a href="https://w3c.github.io/wot-thing-description/#sec-security-considerations">WoT Thing Description</a>
+        <a href="https://www.w3.org/TR/wot-thing-description11/#sec-security-considerations">WoT Thing Description</a>
         <em class="rfc2119">MUST</em> be adopted by compliant implementations.</span>
     </p>
     <div class="note" role="note" id="issue-container-generatedID-18"><div role="heading" class="note-title marker" id="h-note-15" aria-level="3"><span>Note</span></div><p class="">
-      Please see <a href="https://w3c.github.io/wot-security-best-practices/">
+      Please see <a href="https://www.w3.org/TR/wot-security-best-practices/">
         WoT Security Best Practices</a> for implementation advice.
     </p></div>
   </section>

--- a/publication/2-wd/testing/atrisk.css
+++ b/publication/2-wd/testing/atrisk.css
@@ -1,0 +1,471 @@
+#profile-abstract-1 {
+  background-color: yellow;
+}
+#profile-why-a-basic-profile-1-x {
+  background-color: yellow;
+}
+#profiling-mechanism-1 {
+  background-color: yellow;
+}
+#profiling-mechanism-2 {
+  background-color: yellow;
+}
+#profiling-mechanism-3 {
+  background-color: yellow;
+}
+#profiling-mechanism-4 {
+  background-color: yellow;
+}
+#common-constraints-a11y-1 {
+  background-color: yellow;
+}
+#common-constraints-a11y-2 {
+  background-color: yellow;
+}
+#common-constraints-units {
+  background-color: yellow;
+}
+#common-constraints-units-metric {
+  background-color: yellow;
+}
+#common-constraints-date-format-1 {
+  background-color: yellow;
+}
+#common-constraints-security-2 {
+  background-color: yellow;
+}
+#common-constraints-security-3 {
+  background-color: yellow;
+}
+#common-constraints-security-6 {
+  background-color: yellow;
+}
+#common-constraints-security-7 {
+  background-color: yellow;
+}
+#common-constraints-discovery-1 {
+  background-color: yellow;
+}
+#common-constraints-links-1 {
+  background-color: yellow;
+}
+#common-constraints-links-3 {
+  background-color: yellow;
+}
+#common-constraints-links-media-types-1 {
+  background-color: yellow;
+}
+#common-constraints-links-media-types-2 {
+  background-color: yellow;
+}
+#common-constraints-links-media-types-3 {
+  background-color: yellow;
+}
+#common-constraints-errors-3 {
+  background-color: yellow;
+}
+#common-constraints-errors-6 {
+  background-color: yellow;
+}
+#common-constraints-errors-7 {
+  background-color: yellow;
+}
+#common-constraints-default-language {
+  background-color: yellow;
+}
+#http-basic-profile-1 {
+  background-color: yellow;
+}
+#http-basic-profile-identifier-1 {
+  background-color: yellow;
+}
+#profile-5-2-thing-protocol-binding-1 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-readproperty-1 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-readproperty-3 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-readproperty-4 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-writeproperty-1 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-writeproperty-3 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-writeproperty-4 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-readallproperties-1 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-readallproperties-3 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-readallproperties-4 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-writemultipleproperties-1 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-bindings-writemultipleproperties-3 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-writemultipleproperties-4 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-writemultipleproperties-6 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-invokeaction-1 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-invokeaction-3 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-invokeaction-4 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-invokeaction-6 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-invokeaction-7 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-invokeaction-8 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-invokeaction-9 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-invokeaction-11 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-invokeaction-12 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-invokeaction-13 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-invokeaction-14 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-invokeaction-15 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-invokeaction-16 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-invokeaction-17 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-invokeaction-18 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-invokeaction-19 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-invokeaction-20 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-invokeaction-21 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-queryaction-1a {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-queryaction-1b {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-queryaction-2 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-queryaction-3 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-queryaction-5 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-queryaction-7a {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-queryaction-7b {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-cancelaction-1a {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-cancelaction-1b {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-cancelaction-2 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-cancelaction-3 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-queryallactions-1 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-queryallactions-3 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-queryallactions-4 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-queryallactions-6a {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-queryallactions-6b {
+  background-color: yellow;
+}
+#http-sse-profile-1 {
+  background-color: yellow;
+}
+#http-sse-profile-identifier-1 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-1 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeproperty-1 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeproperty-2 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeproperty-3 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeproperty-4 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeproperty-5a {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeproperty-5b {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeproperty-5c {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeproperty-5d {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeproperty-6a {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeproperty-6b {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-unobserveproperty-1 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeallproperties-1 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeallproperties-2 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeallproperties-3 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeallproperties-4 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeallproperties-5a {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeallproperties-5b {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeallproperties-5c {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeallproperties-5d {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeallproperties-5e {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeallproperties-6a {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-observeallproperties-6b {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-unobserveallproperties-1 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeevent-1 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeevent-3 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeevent-4 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeevent-5 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeevent-6a {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeevent-6b {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeevent-6c {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeevent-6d {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeevent-6e {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeevent-7a {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeevent-7b {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-unsubscribeevent-1 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeallevents-1 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeallevents-3b {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeallevents-4 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeallevents-3 {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeallevents-4a {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeallevents-4b {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeallevents-4c {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeallevents-4d {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeallevents-4e {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeallevents-5a {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-subscribeallevents-5b {
+  background-color: yellow;
+}
+#http-sse-profile-protocol-binding-unsubscribeallevents-1 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-general-1 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-general-3 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-events-1 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-events-2 {
+  background-color: yellow;
+}
+#http-webhook-profile-1 {
+  background-color: yellow;
+}
+#http-webhook-profile-message-format-1 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-1 {
+  background-color: yellow;
+}
+#http-basic-profile-protocol-binding-subscribeevent-1 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-subscribeevent-3 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-subscribeevent-4 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-subscribeevent-5 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-subscribeevent-6 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-subscribeevent-4b {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-subscribeallevents-1 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-subscribeallevents-3 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-subscribeallevents-4 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-subscribeallevents-5 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-subscribeallevents-6 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-subscribeallevents-7 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-subscribeallevents-8 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-unsubscribeallevents-1 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-event-connections-1 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-event-connections-2 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-event-connections-3 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-event-connections-4 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding--event-connections-5 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-event-connections-6 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-event-connections-7 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding--event-connections-8 {
+  background-color: yellow;
+}
+#http-webhook-profile-protocol-binding-event-connections-9 {
+  background-color: yellow;
+}
+#privacy-considerations-1 {
+  background-color: yellow;
+}
+#security-considerations-1 {
+  background-color: yellow;
+}


### PR DESCRIPTION
Fix link errors caught by link checker
- Update github.io references to www.w3.org/TR references
- convert wot-architecture references to wot-architecture11 references
- convert wot-thing-description references to wot-thing-description11 references
- add copy of testing/atrisk.css to resolve link to it (this means atrisk items will be marked in yellow, even though this is not necessary for a WD nor is it explained)

This PR makes changes only to the files in publication/2-wd.   I need to merge these immediately so I can run through the link checker again to check if the problems have been fixed.  However, this PR does not touch the root index.html - although at a later date we need to make sure these changes are propagated to it.