### PR TITLE
Prepare 2-WD Release (phase 3)

### DIFF
--- a/publication/2-wd/Overview.html
+++ b/publication/2-wd/Overview.html
@@ -2428,7 +2428,7 @@ is set to <code>true</code> then the Web Thing <em class=
 <p><span class="rfc2119-assertion" id=
 "http-basic-profile-protocol-binding-invokeaction-8">If the
 <code>synchronous</code> member of the <a href=
-"https://www.w3.org/wot-thing-description11/#actionaffordance"><code>
+"https://www.w3.org/TR/wot-thing-description11/#actionaffordance"><code>
 ActionAffordance</code></a> [<cite><a class="bibref"
 data-link-type="biblio" href="#bib-wot-thing-description11" title=
 "Web of Things (WoT) Thing Description 1.1">wot-thing-description11</a></cite>]

--- a/publication/2-wd/Overview.html
+++ b/publication/2-wd/Overview.html
@@ -4669,13 +4669,6 @@ WoT Architecture</a> and <a href=
 "https://www.w3.org/TR/wot-thing-description11/#sec-security-consideration">
 WoT Thing Description</a> <em class="rfc2119">MUST</em> be adopted
 by compliant implementations.</span></p>
-<div class="note" role="note" id="issue-container-generatedID-18">
-<div role="heading" class="note-title marker" id="h-note-15"
-aria-level="3"><span>Note</span></div>
-<p class="">Please see <a href=
-"https://www.w3.org/TR/wot-security-best-practices/">WoT Security
-Best Practices</a> for implementation advice.</p>
-</div>
 </section>
 <section id="changes" class="appendix">
 <div class="header-wrapper">

--- a/publication/2-wd/Overview.html
+++ b/publication/2-wd/Overview.html
@@ -4664,9 +4664,9 @@ Security Considerations</h2>
 <p><span class="rfc2119-assertion" id=
 "security-considerations-1">The security considerations of the
 <a href=
-"https://www.w3.org/TR/wot-architecture11/#sec-security-consideration">
+"https://www.w3.org/TR/wot-architecture11/#sec-security-considerations">
 WoT Architecture</a> and <a href=
-"https://www.w3.org/TR/wot-thing-description11/#sec-security-considerations">
+"https://www.w3.org/TR/wot-thing-description11/#sec-security-consideration">
 WoT Thing Description</a> <em class="rfc2119">MUST</em> be adopted
 by compliant implementations.</span></p>
 <div class="note" role="note" id="issue-container-generatedID-18">

--- a/publication/2-wd/index.html
+++ b/publication/2-wd/index.html
@@ -3369,9 +3369,9 @@
     <h4>Security Considerations</h4>
     <p><span class="rfc2119-assertion" id="security-considerations-1">
         The security considerations of the
-        <a href="https://www.w3.org/TR/wot-architecture11/#sec-security-consideration">WoT Architecture</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#sec-security-considerations">WoT Architecture</a>
         and
-        <a href="https://www.w3.org/TR/wot-thing-description11/#sec-security-considerations">WoT Thing Description</a>
+        <a href="https://www.w3.org/TR/wot-thing-description11/#sec-security-consideration">WoT Thing Description</a>
         MUST be adopted by compliant implementations.</span>
     </p>
     <p class="note">

--- a/publication/2-wd/index.html
+++ b/publication/2-wd/index.html
@@ -3374,10 +3374,12 @@
         <a href="https://www.w3.org/TR/wot-thing-description11/#sec-security-consideration">WoT Thing Description</a>
         MUST be adopted by compliant implementations.</span>
     </p>
+<!-- not yet published, remove temporarily
     <p class="note">
       Please see <a href="https://www.w3.org/TR/wot-security-best-practices/">
         WoT Security Best Practices</a> for implementation advice.
     </p>
+-->
   </section>
 
   <!---------------------------------------------------------------->

--- a/publication/2-wd/index.html
+++ b/publication/2-wd/index.html
@@ -1572,7 +1572,7 @@
             <span class="rfc2119-assertion" 
             id="http-basic-profile-protocol-binding-invokeaction-8">
               If the <code>synchronous</code> member of the 
-              <a href="https://www.w3.org/wot-thing-description11/#actionaffordance"><code>ActionAffordance</code></a>
+              <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance"><code>ActionAffordance</code></a>
               [[wot-thing-description11]] is set to <code>false</code> then the Web 
               Thing MUST respond with an
               <a href="#async-action-response">Asynchronous Action Response</a>.

--- a/publication/2-wd/static.html
+++ b/publication/2-wd/static.html
@@ -1849,7 +1849,7 @@ Accept: application/json
           <p>
             <span class="rfc2119-assertion" id="http-basic-profile-protocol-binding-invokeaction-8">
               If the <code>synchronous</code> member of the 
-              <a href="https://www.w3.org/wot-thing-description11/#actionaffordance"><code>ActionAffordance</code></a>
+              <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance"><code>ActionAffordance</code></a>
               [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-thing-description11" title="Web of Things (WoT) Thing Description 1.1">wot-thing-description11</a></cite>] is set to <code>false</code> then the Web 
               Thing <em class="rfc2119">MUST</em> respond with an
               <a href="#async-action-response">Asynchronous Action Response</a>.

--- a/publication/2-wd/static.html
+++ b/publication/2-wd/static.html
@@ -3716,9 +3716,9 @@ id: 2021-11-16T16:53:50.817Z\n\n</code></pre>
     
     <p><span class="rfc2119-assertion" id="security-considerations-1">
         The security considerations of the
-        <a href="https://www.w3.org/TR/wot-architecture11/#sec-security-consideration">WoT Architecture</a>
+        <a href="https://www.w3.org/TR/wot-architecture11/#sec-security-considerations">WoT Architecture</a>
         and
-        <a href="https://www.w3.org/TR/wot-thing-description11/#sec-security-considerations">WoT Thing Description</a>
+        <a href="https://www.w3.org/TR/wot-thing-description11/#sec-security-consideration">WoT Thing Description</a>
         <em class="rfc2119">MUST</em> be adopted by compliant implementations.</span>
     </p>
     <div class="note" role="note" id="issue-container-generatedID-18"><div role="heading" class="note-title marker" id="h-note-15" aria-level="3"><span>Note</span></div><p class="">

--- a/publication/2-wd/static.html
+++ b/publication/2-wd/static.html
@@ -3721,10 +3721,7 @@ id: 2021-11-16T16:53:50.817Z\n\n</code></pre>
         <a href="https://www.w3.org/TR/wot-thing-description11/#sec-security-consideration">WoT Thing Description</a>
         <em class="rfc2119">MUST</em> be adopted by compliant implementations.</span>
     </p>
-    <div class="note" role="note" id="issue-container-generatedID-18"><div role="heading" class="note-title marker" id="h-note-15" aria-level="3"><span>Note</span></div><p class="">
-      Please see <a href="https://www.w3.org/TR/wot-security-best-practices/">
-        WoT Security Best Practices</a> for implementation advice.
-    </p></div>
+
   </section>
 
   


### PR DESCRIPTION
Fix additional errors
- remove reference to wot-security-best-practices
- fix typos in urls and fragment identifiers (missing TR in one URL, sometime sec-security-considerations is plural, sometimes not...)

Still some errors but we can ignore.  For example, the event-source reference has a "permanent" redirect to whatwg but this is being migrated back to W3C, and the link does work, so it's not really an error.  Likewise there is a self-link to the new URL of this document which is broken since it's not yet published.

Merging immediately so I can run link checker again...