### PR TITLE
Prepare 2-WD Release (phase 4)

### DIFF
--- a/publication/2-wd/Overview.html
+++ b/publication/2-wd/Overview.html
@@ -159,8 +159,11 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "group": "wg/wot",
   "wgPublicList": "public-wot-wg",
   "edDraftURI": "https://w3c.github.io/wot-profile/",
-  "githubAPI": "https://api.github.com/repos/w3c/wot-profile",
-  "issueBase": "https://www.github.com/w3c/wot-profile/issues",
+  "issueBase": "https://github.com/w3c/wot-profile/issues",
+  "github": {
+    "repoURL": "https://github.com/w3c/wot-profile",
+    "branch": "main"
+  },
   "previousPublishDate": "2020-11-24",
   "previousMaturity": "FPWD",
   "editors": [
@@ -290,6 +293,9 @@ src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width=
 <dt>History:</dt>
 <dd><a href=
 "https://www.w3.org/standards/history/wot-profile">https://www.w3.org/standards/history/wot-profile</a></dd>
+<dd><a href=
+"https://github.com/w3c/wot-profile/commits/main">Commit
+history</a></dd>
 <dt>Editors:</dt>
 <dd class="editor p-author h-card vcard" data-editor-id="47166">
 <span class="p-name fn">Michael Lagally</span> (<a class=
@@ -315,6 +321,12 @@ AG</a>)</dd>
 "p-org org h-org" href="https://www.iri.co.jp/">Internet Research
 Institute, Inc.</a>)</dd>
 <dt>Feedback:</dt>
+<dd><a href="https://github.com/w3c/wot-profile/">GitHub
+w3c/wot-profile</a> (<a href=
+"https://github.com/w3c/wot-profile/pulls/">pull requests</a>,
+<a href="https://github.com/w3c/wot-profile/issues/new/choose">new
+issue</a>, <a href=
+"https://github.com/w3c/wot-profile/issues/">open issues</a>)</dd>
 <dd><a href=
 "mailto:public-wot-wg@w3.org?subject=%5Bwot-profile%5D%20YOUR%20TOPIC%20HERE">
 public-wot-wg@w3.org</a> with subject line <kbd>[wot-profile] <em>…
@@ -4351,9 +4363,9 @@ Thing with:</p>
 <code>application/json</code></li>
 <li>A body with a subscription request payload, serialized in
 JSON.</li>
+</ul>
 <p>The subscription payload contains the URI for the event message
 listener in the field with the <code>callbackURI</code> key.</p>
-</ul>
 <div class="example" id="example-45">
 <div class="marker"><a class="self-link" href="#example-45">Example
 <bdi>45</bdi></a></div>

--- a/publication/2-wd/index.html
+++ b/publication/2-wd/index.html
@@ -19,8 +19,11 @@
       group: "wg/wot",
       wgPublicList: "public-wot-wg",
       edDraftURI: "https://w3c.github.io/wot-profile/",
-      githubAPI: "https://api.github.com/repos/w3c/wot-profile",
-      issueBase: "https://www.github.com/w3c/wot-profile/issues",
+      issueBase: "https://github.com/w3c/wot-profile/issues",
+      github: {
+        repoURL: "https://github.com/w3c/wot-profile",
+        branch: "main"
+      },
       previousPublishDate: "2020-11-24",
       previousMaturity: "FPWD",
       editors: [{
@@ -3100,12 +3103,11 @@
             <li>
               A body with a subscription request payload, serialized in JSON.
             </li>
+          </ul>
             <p>
               The subscription payload contains the URI for the event message listener
               in the field with the <code>callbackURI</code> key. 
             </p>
-
-          </ul>
           <pre class="example">
               POST /things/lamp/events/overheated HTTP/1.1
               Host: mythingserver.com

--- a/publication/2-wd/static.html
+++ b/publication/2-wd/static.html
@@ -161,8 +161,11 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "group": "wg/wot",
   "wgPublicList": "public-wot-wg",
   "edDraftURI": "https://w3c.github.io/wot-profile/",
-  "githubAPI": "https://api.github.com/repos/w3c/wot-profile",
-  "issueBase": "https://www.github.com/w3c/wot-profile/issues",
+  "issueBase": "https://github.com/w3c/wot-profile/issues",
+  "github": {
+    "repoURL": "https://github.com/w3c/wot-profile",
+    "branch": "main"
+  },
   "previousPublishDate": "2020-11-24",
   "previousMaturity": "FPWD",
   "editors": [
@@ -281,6 +284,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
         <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/wot-profile/">https://w3c.github.io/wot-profile/</a></dd>
         <dt>History:</dt><dd>
                     <a href="https://www.w3.org/standards/history/wot-profile">https://www.w3.org/standards/history/wot-profile</a>
+                  </dd><dd>
+                    <a href="https://github.com/w3c/wot-profile/commits/main">Commit history</a>
                   </dd>
         
         
@@ -302,7 +307,12 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   </dd>
         
         
-        <dt>Feedback:</dt><dd><a href="mailto:public-wot-wg@w3.org?subject=%5Bwot-profile%5D%20YOUR%20TOPIC%20HERE">public-wot-wg@w3.org</a> with subject line <kbd>[wot-profile] <em>… message topic …</em></kbd> (<a rel="discussion" href="https://lists.w3.org/Archives/Public/public-wot-wg">archives</a>)</dd>
+        <dt>Feedback:</dt><dd>
+        <a href="https://github.com/w3c/wot-profile/">GitHub w3c/wot-profile</a>
+        (<a href="https://github.com/w3c/wot-profile/pulls/">pull requests</a>,
+        <a href="https://github.com/w3c/wot-profile/issues/new/choose">new issue</a>,
+        <a href="https://github.com/w3c/wot-profile/issues/">open issues</a>)
+      </dd><dd><a href="mailto:public-wot-wg@w3.org?subject=%5Bwot-profile%5D%20YOUR%20TOPIC%20HERE">public-wot-wg@w3.org</a> with subject line <kbd>[wot-profile] <em>… message topic …</em></kbd> (<a rel="discussion" href="https://lists.w3.org/Archives/Public/public-wot-wg">archives</a>)</dd>
         
         <dt>Contributors</dt><dd>
     <a href="https://github.com/w3c/wot-profile/graphs/contributors">In the GitHub repository</a>
@@ -3437,12 +3447,11 @@ id: 2021-11-16T16:53:50.817Z\n\n</code></pre>
             <li>
               A body with a subscription request payload, serialized in JSON.
             </li>
+          </ul>
             <p>
               The subscription payload contains the URI for the event message listener
               in the field with the <code>callbackURI</code> key. 
             </p>
-
-          </ul>
           <div class="example" id="example-45">
         <div class="marker">
     <a class="self-link" href="#example-45">Example<bdi> 45</bdi></a>


### PR DESCRIPTION
Fix two pub rule checker errors:
- "No GitHub repository issue link."
    - this was due to a change in how the github link needs to be declared to ReSpec.  Updated.
- Element “p” not allowed as child of element “ul”
    - Near line 3104 in index.html, a paragraph seems to have been accidentally inserted inside a list
    - close ul tag moved up above paragraph

Only changes files in publication/2-wd.  Merging immediately so I can re-run checker.