### PR TITLE
Prepare 2-WD Release (phase 5)

### DIFF
--- a/publication/2-wd/Overview.html
+++ b/publication/2-wd/Overview.html
@@ -234,7 +234,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "localBiblio": {
     "JSON-SCHEMA": {
       "title": "JSON Schema Validation: A Vocabulary for Structural Validation of JSON",
-      "href": "https://tools.ietf.org/html/draft-handrews-json-schema-validation-01",
+      "href": "https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-01",
       "authors": [
         "Austin Wright",
         "Henry Andrews",
@@ -2040,7 +2040,7 @@ inside the corresponding <a href=
 <li>After defaults have been applied, its <code>op</code> member
 contains the value <code>readproperty</code>.</li>
 <li>After being resolved against a base URL where applicable, the
-<a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+<a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
 scheme</a> [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-rfc3986" title=
 "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]
@@ -2116,7 +2116,7 @@ inside the corresponding <a href=
 <li>After defaults have been applied, its <code>op</code> member
 contains the value <code>writeproperty</code></li>
 <li>After being resolved against a base URL where applicable, the
-<a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+<a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
 scheme</a> [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-rfc3986" title=
 "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]
@@ -2190,7 +2190,7 @@ inside the top level <a href=
 <li>Its <code>op</code> member contains the value
 <code>readallproperties</code></li>
 <li>After being resolved against a base URL where applicable, the
-<a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+<a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
 scheme</a> [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-rfc3986" title=
 "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]
@@ -2274,7 +2274,7 @@ inside the top level <a href=
 <li>Its <code>op</code> member contains the value
 <code>writemultipleproperties</code></li>
 <li>After being resolved against a base URL where applicable, the
-<a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+<a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
 scheme</a> [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-rfc3986" title=
 "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]
@@ -2370,7 +2370,7 @@ ActionAffordance</code></a> for which:</p>
 <li>After defaults have been applied, the value of its
 <code>op</code> member is <code>invokeaction</code></li>
 <li>After being resolved against a base URL where applicable, the
-<a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+<a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
 scheme</a> [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-rfc3986" title=
 "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]
@@ -2554,7 +2554,7 @@ operation).</td>
 "#bib-url" title="URL Standard">URL</a></cite>] of an
 <code>ActionStatus</code> resource which can be used by
 <code>queryaction</code> and <code>cancelaction</code> operations,
-the <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+the <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
 scheme</a> [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-rfc3986" title=
 "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]
@@ -2632,7 +2632,7 @@ Asynchronous Action Response</h6>
 <p>If providing an Asynchronous Action Response, a Web Thing
 <em class="rfc2119">MUST</em> send an HTTP response containing the
 URL of an <code>ActionStatus</code> resource, the <a href=
-"https://tools.ietf.org/html/rfc3986#section-3.1">URI scheme</a>
+"https://rfc-editor.org/rfc/rfc3986#section-3.1">URI scheme</a>
 [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-rfc3986" title=
 "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]
@@ -2877,7 +2877,7 @@ inside the top level <a href=
 <li>Its <code>op</code> member contains the value
 <code>queryallactions</code></li>
 <li>After being resolved against a base URL where applicable, the
-<a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+<a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
 scheme</a> [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-rfc3986" title=
 "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]
@@ -3246,7 +3246,7 @@ inside the corresponding <a href=
 <li>Its <code>op</code> member contains the value
 <code>observeproperty</code></li>
 <li>After being resolved against a base URL where applicable, the
-<a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+<a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
 scheme</a> [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-rfc3986" title=
 "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]
@@ -3446,7 +3446,7 @@ inside the top level <a href=
 <li>Its <code>op</code> member contains the value
 <code>observeallproperties</code></li>
 <li>After being resolved against a base URL where applicable, the
-<a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+<a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
 scheme</a> [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-rfc3986" title=
 "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]
@@ -3670,7 +3670,7 @@ EventAffordance</code></a> for which:</p>
 <li>After defaults have been applied, its <code>op</code> member
 contains the value <code>subscribeevent</code></li>
 <li>After being resolved against a base URL where applicable, the
-<a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+<a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
 scheme</a> [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-rfc3986" title=
 "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]
@@ -3874,7 +3874,7 @@ inside the top level <a href=
 <li>Its <code>op</code> member contains the value
 <code>subscribeallevents</code></li>
 <li>After being resolved against a base URL where applicable, the
-<a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+<a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
 scheme</a> [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-rfc3986" title=
 "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]
@@ -4333,7 +4333,7 @@ EventAffordance</code></a> for which:</p>
 <li>After defaults have been applied, its <code>op</code> member
 contains the value <code>subscribeevent</code></li>
 <li>After being resolved against a base URL where applicable, the
-<a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+<a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
 scheme</a> [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-rfc3986" title=
 "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]
@@ -4469,7 +4469,7 @@ inside the top level <a href=
 <li>Its <code>op</code> member contains the value
 <code>subscribeallevents</code></li>
 <li>After being resolved against a base URL where applicable, the
-<a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+<a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
 scheme</a> [<cite><a class="bibref" data-link-type="biblio" href=
 "#bib-rfc3986" title=
 "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]

--- a/publication/2-wd/index.html
+++ b/publication/2-wd/index.html
@@ -86,7 +86,7 @@
       localBiblio: {
         "JSON-SCHEMA": {
           title: "JSON Schema Validation: A Vocabulary for Structural Validation of JSON",
-          href: "https://tools.ietf.org/html/draft-handrews-json-schema-validation-01",
+          href: "https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-01",
           authors: ["Austin Wright", "Henry Andrews", "Geraint Luff"],
           status: "Internet-Draft",
           date: "19 March 2018",
@@ -1222,7 +1222,7 @@
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [[RFC3986]] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -1289,7 +1289,7 @@
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [[RFC3986]] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -1353,7 +1353,7 @@
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [[RFC3986]] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -1427,7 +1427,7 @@
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [[RFC3986]] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -1509,7 +1509,7 @@
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [[RFC3986]] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -1677,7 +1677,7 @@
                     The [[URL]] of an <code>ActionStatus</code> resource which
                     can be used by <code>queryaction</code> and 
                     <code>cancelaction</code> operations, the
-                    <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                    <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                       scheme</a> [[RFC3986]] of which MUST resolve to
                     <code>http</code> or <code>https</code> (only needed for an
                     <a href="#async-action-response">Asynchronous Action
@@ -1747,7 +1747,7 @@
               If providing an Asynchronous Action Response, a Web Thing MUST send
               an HTTP response containing the URL of an <code>ActionStatus</code>
               resource, the
-              <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+              <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                 scheme</a> [[RFC3986]] of which MUST resolve to <code>http</code>
               or <code>https</code>. The response MUST have:
             </p>
@@ -1961,7 +1961,7 @@
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [[RFC3986]] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -2238,7 +2238,7 @@
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [[RFC3986]] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -2398,7 +2398,7 @@
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [[RFC3986]] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -2573,7 +2573,7 @@
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [[RFC3986]] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -2730,7 +2730,7 @@
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [[RFC3986]] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -3072,7 +3072,7 @@
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [[RFC3986]] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -3200,7 +3200,7 @@
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [[RFC3986]] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>

--- a/publication/2-wd/static.html
+++ b/publication/2-wd/static.html
@@ -236,7 +236,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "localBiblio": {
     "JSON-SCHEMA": {
       "title": "JSON Schema Validation: A Vocabulary for Structural Validation of JSON",
-      "href": "https://tools.ietf.org/html/draft-handrews-json-schema-validation-01",
+      "href": "https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-01",
       "authors": [
         "Austin Wright",
         "Henry Andrews",
@@ -1490,7 +1490,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -1561,7 +1561,7 @@ false</code></pre>
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -1629,7 +1629,7 @@ Content-Type: application/json
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -1707,7 +1707,7 @@ Content-Type: application/json
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -1793,7 +1793,7 @@ Content-Type: application/json
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -1960,7 +1960,7 @@ Accept: application/json
                     The [<cite><a class="bibref" data-link-type="biblio" href="#bib-url" title="URL Standard">URL</a></cite>] of an <code>ActionStatus</code> resource which
                     can be used by <code>queryaction</code> and 
                     <code>cancelaction</code> operations, the
-                    <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                    <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                       scheme</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] of which <em class="rfc2119">MUST</em> resolve to
                     <code>http</code> or <code>https</code> (only needed for an
                     <a href="#async-action-response">Asynchronous Action
@@ -2032,7 +2032,7 @@ Accept: application/json
               If providing an Asynchronous Action Response, a Web Thing <em class="rfc2119">MUST</em> send
               an HTTP response containing the URL of an <code>ActionStatus</code>
               resource, the
-              <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+              <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                 scheme</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] of which <em class="rfc2119">MUST</em> resolve to <code>http</code>
               or <code>https</code>. The response <em class="rfc2119">MUST</em> have:
             </p>
@@ -2258,7 +2258,7 @@ Accept: application/json</code></pre>
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -2541,7 +2541,7 @@ Accept: application/json</code></pre>
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -2711,7 +2711,7 @@ id: 2021-11-17T15:33:20.827Z\n\n</code></pre>
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -2896,7 +2896,7 @@ id: 2021-11-17T15:33:20.827Z\n\n</code></pre>
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -3063,7 +3063,7 @@ id: 2021-11-16T16:53:50.817Z\n\n</code></pre>
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -3416,7 +3416,7 @@ id: 2021-11-16T16:53:50.817Z\n\n</code></pre>
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>
@@ -3549,7 +3549,7 @@ id: 2021-11-16T16:53:50.817Z\n\n</code></pre>
               </li>
               <li>
                 After being resolved against a base URL where applicable, the
-                <a href="https://tools.ietf.org/html/rfc3986#section-3.1">URI
+                <a href="https://rfc-editor.org/rfc/rfc3986#section-3.1">URI
                   scheme</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] of the value of its <code>href</code>
                 member is <code>http</code> or <code>https</code>
               </li>


### PR DESCRIPTION
Fix pub rules warnings
- update in-text direct links to tools.ietf to use rfc-editor instead
- update link in references to use datatracker instead of tools.ietf

These also avoid some redirection warnings in the link checker.

Need to merge, then will re-run both pubrule and link checker.