### PR TITLE
Define values of in and name for basic security scheme

### DIFF
--- a/index.html
+++ b/index.html
@@ -652,6 +652,16 @@
         <p><span class="rfc2119-assertion" id="common-constraints-security-4">
             A Thing MUST support at least one of the above security schemes.</span>
         </p>
+        <p><span class="rfc2119-assertion" id="common-constraints-security-basic-in">
+            For the <code>BasicSecurityScheme</code> the "in" field MUST be either omitted
+            or be given its default value of "header" as defined in [[wot-thing-description11].</span>
+           <span class="rfc2119-assertion" id="common-constraints-security-basic-name">
+            For the <code>BasicSecurityScheme</code> the "name" field MUST be provided using
+            the value "Authorization" if a "proxy" endpoint is not given.</span>
+           <span class="rfc2119-assertion" id="common-constraints-security-basic-proxy">
+            For the <code>BasicSecurityScheme</code> the "name" field MUST be provided using
+            the value "Proxy-Authorization" if a"proxy" endpoint is given.</span>
+        </p>
 
         <p><span class="rfc2119-assertion" id="common-constraints-security-6">
           Conformant Consumers MUST support security bootstrapping for all


### PR DESCRIPTION
In Issue #6  we noted some missing details around the parameters for the "basic" security scheme that this PR tries to address:
- "in" should be "header".  As this is the default value, you can just leave it out.  This PR adds an assertion saying you can either leave it out or use the default value of "header".
- The value for "name" is trickier.  First, it does not have a default value, but is optional, which frankly is an oversight; it means it is technically undefined if not given.  However, in the HTTP specification it also has two possible values, whether or not a proxy is used.
- This PR adds two assertions for "name", one for when a proxy is used, one for when it is not.  For compatibility with the TD spec while avoiding undefined terms, this also means that "name" must ALWAYS be given.  An alternative would be to *define* a default value for it using these rules.

We also haven't said anything about proxies in the profiles spec, but the current text does not disallow them that I can see.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-profile/pull/374.html" title="Last updated on Mar 6, 2023, 2:49 PM UTC (196805f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/374/439d590...mmccool:196805f.html" title="Last updated on Mar 6, 2023, 2:49 PM UTC (196805f)">Diff</a>