### PR TITLE
Make sychronous member of ActionAffordance mandatory - closes #405

### DIFF
--- a/index.html
+++ b/index.html
@@ -969,6 +969,7 @@
               "fade": {
                 "title": "Fade",
                 "description": "Fade the lamp to a given level",
+                "synchronous": false,
                 "input": {
                   "type": "object",
                   "properties": {
@@ -1366,6 +1367,14 @@
           </div>
           <p>
             <span class="rfc2119-assertion"
+            id="http-basic-profile-protocol-binding-invokeaction-24">
+              The <code>synchronous</code> member of an 
+              <a href="https://w3c.github.io/wot-thing-description/#actionaffordance"><code>ActionAffordance</code></a>
+              MUST be set to <code>true</code> or <code>false</code>.
+            </span>
+          </p>
+          <p>
+            <span class="rfc2119-assertion"
             id="http-basic-profile-protocol-binding-invokeaction-7">
               If the <code>synchronous</code> member of the
               <a href="https://w3c.github.io/wot-thing-description/#actionaffordance"><code>ActionAffordance</code></a>
@@ -1381,17 +1390,6 @@
               <a href="https://w3c.github.io/wot-thing-description/#actionaffordance"><code>ActionAffordance</code></a>
               [[wot-thing-description11]] is set to <code>false</code> then the Web
               Thing MUST respond with an
-              <a href="#async-action-response">Asynchronous Action Response</a>.
-            </span>
-          </p>
-          <p>
-            <span class="rfc2119-assertion"
-            id="http-basic-profile-protocol-binding-invokeaction-9">
-              If the <code>synchronous</code> member of the
-              <a href="https://w3c.github.io/wot-thing-description/#actionaffordance"><code>ActionAffordance</code></a>
-              [[wot-thing-description11]] is <code>undefined</code> then the Web
-              Thing MAY respond with either a
-              <a href="#sync-action-response">Synchronous Action Response</a> or
               <a href="#async-action-response">Asynchronous Action Response</a>.
             </span>
           </p>
@@ -1970,6 +1968,7 @@
             "fade": {
               "title": "Fade",
               "description": "Fade the lamp to a given level",
+              "synchronous": false,
               "input": {
                 "type": "object",
                 "properties": {

--- a/testing/atrisk.css
+++ b/testing/atrisk.css
@@ -103,6 +103,9 @@
 #http-basic-profile-protocol-binding-invokeaction-23 {
   background-color: yellow;
 }
+#http-basic-profile-protocol-binding-invokeaction-24 {
+  background-color: yellow;
+}
 #http-basic-profile-protocol-binding-queryaction-2 {
   background-color: yellow;
 }


### PR DESCRIPTION
closes #405

I don't like that this adds an additional mandatory term to ActionAffordances, but if this really is currently the only case where a Thing compliant with the HTTP Basic Profile will break a generic Consumer, then I think it's worth being more strict.

(I would also be happy to just make it mandatory for async actions to set `synchronous` to `false`)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/408.html" title="Last updated on Apr 30, 2024, 2:58 PM UTC (cf660f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/408/9a996de...benfrancis:cf660f7.html" title="Last updated on Apr 30, 2024, 2:58 PM UTC (cf660f7)">Diff</a>