### PR TITLE
 Common constraints section is applicable to the entire document  

### DIFF
--- a/index.html
+++ b/index.html
@@ -453,7 +453,7 @@
   <section id="common-constraints">
     <h1>Common Constraints</h1>
     <p>
-      The following sections are applicable for all of the HTTP profiles defined by this document.
+      The following sections are applicable for profiles defined by this document.
     </p>
 
     <!-- Identifiers TODO -->


### PR DESCRIPTION
Hence, no need to specify HTTP.

Popped up while discussing https://github.com/w3c/wot-profile/issues/323 in the call.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/pull/424.html" title="Last updated on Jun 25, 2025, 1:52 PM UTC (3276aaf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/424/86847c8...3276aaf.html" title="Last updated on Jun 25, 2025, 1:52 PM UTC (3276aaf)">Diff</a>