### PR TITLE
Profiling mechanism clarifications - closes #385, closes #403, closes #404

### DIFF
--- a/index.html
+++ b/index.html
@@ -448,7 +448,7 @@
       <span class="rfc2119-assertion" id="profiling-mechanism-6">
         A <a>Profile</a> SHOULD NOT redefine defaults from protocol binding templates [[wot-binding-templates]].
       </span>
-      E.g. If a profile uses an HTTP protocol binding and the HTTP Binding Template specifies that in an 
+      E.g., if a profile uses an HTTP protocol binding and the HTTP Binding Template specifies that in an 
       HTTP protocol binding the default value of <code>htv:methodName</code> for a <code>readproperty</code>
       operation is <code>GET</code>, the profile should not redefine that value as <code>POST</code>.
     </p>
@@ -457,10 +457,10 @@
         A <a>Profile</a> SHOULD NOT require a <a>Thing</a> to respond in a way which would be unexpected by a 
         <a>Consumer</a> which does not implement the <a>Profile</a>.
       </span>
-      E.g. A <a>Profile</a> may define details of a protocol binding for a <code>queryaction</code> operation which would not
+      E.g., a <a>Profile</a> may define details of a protocol binding for a <code>queryaction</code> operation which would not
       currently be possible to fully describe using a protocol binding template in a <a>Thing Description</a> (due to
       current limitations of the WoT Thing Description 1.1 specification), and would be consumable by a conformant
-      <a>Consumer</a>, but any other action-related operations exposed by the <a>Thing Description</a> should still
+      <a>Consumer</a>, but any other action-related operations exposed by the <a>Thing Description</a> ought to still
       respond in the way that a Consumer which does not implement the <a>Profile</a> would expect.
     </p>
     <p class="note">
@@ -470,7 +470,7 @@
       the normative assertions of the <a>Profile</a>.
     </p>
     <p class="note">
-      Just because a <a>Thing Description</a> denotes that the Thing it describes conforms to a given <a>Profile</a>,
+      Just because a <a>Thing Description</a> claims that the Thing it describes conforms to a given <a>Profile</a>,
       a <a>Consumer</a> should not assume that it does in fact conform. E.g. a <a>Consumer</a> should be able 
       to recover gracefully if a <a>Thing</a> does not respond as specified to a given operation.
     </p>


### PR DESCRIPTION
- Closes #385 
- Closes #403 
- Closes #404 

This PR is an attempt to clarify three open issues about the profiling mechanism, the scope of what profiles are allowed to do, and the assumptions it is safe for Consumers to make.

Specifically:
- A profile SHOULD NOT redefine defaults from protocol binding templates.
- A profile SHOULD NOT require a Thing to respond in a way which a non-conformant Consumer would not expect.
- Note: Just because a Thing Description denotes that the Thing it describes conforms to a given profile, a Consumer should not assume that it does in fact conform.

The devil is in the details and the wording of the examples given.

When reviewing, please bear in mind that I think these clarifications are needed for Profiles 1.0 but we should hopefully have better answers to these issues in 2.0.

Let me know what you think.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/431.html" title="Last updated on Jul 28, 2025, 5:59 PM UTC (1c86b45)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/431/637100f...benfrancis:1c86b45.html" title="Last updated on Jul 28, 2025, 5:59 PM UTC (1c86b45)">Diff</a>