### PR TITLE
Fix broken link to Profile requirements - closes #434

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@
       </p>
       <p>
         A set of
-        <a href="https://github.com/w3c/wot-profile/blob/main/REQUIREMENTS.md">requirements</a>
+        <a href="https://w3c.github.io/wot-profile/profile-1.x-requirements.html">requirements</a>
         for Profiles were derived from these use cases.
       </p>
     </section>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/435.html" title="Last updated on Jul 23, 2025, 11:23 AM UTC (b7655b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/435/637100f...benfrancis:b7655b4.html" title="Last updated on Jul 23, 2025, 11:23 AM UTC (b7655b4)">Diff</a>