### PR TITLE
Clarify behaviour when an HTTP request or response does not have a body - closes #360

### DIFF
--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@
           </p>
           <p class="note">
             Valid JSON values such as <code>null</code>, <code>""</code> and <code>{}</code> could be a valid 
-            action input and are not be considered to be an "empty" body.
+            action input and are not considered to be an "empty" body.
           </p>
           <div class="rfc2119-assertion" id="http-basic-profile-protocol-binding-invokeaction-6">
             <p>
@@ -1416,7 +1416,7 @@
           </pre>
           <p class="note">
             Valid JSON values such as <code>null</code>, <code>""</code> and <code>{}</code> could be a valid 
-            action output and are not be considered to be an "empty" body.
+            action output and are not considered to be an "empty" body.
           </p>
           <h6 id="async-action-response">Asynchronous Action Response</h6>
           <div class="rfc2119-assertion" id="http-basic-profile-protocol-binding-invokeaction-21">
@@ -3251,7 +3251,7 @@
           </span></p>
           <p class="note">
             Valid JSON values such as <code>null</code>, <code>""</code> and <code>{}</code> could be a valid 
-            data payload and are not be considered to be an "empty" body.
+            data payload and are not considered to be an "empty" body.
           </p>
           <pre class="example" title="Event notification request">
             POST /listeners/e79dd0a5-4537-4ded-a10f-bb4eb2aca28d HTTP/1.1
@@ -3415,7 +3415,7 @@
           </span></p>
           <p class="note">
             Valid JSON values such as <code>null</code>, <code>""</code> and <code>{}</code> could be a valid 
-            data payload and are not be considered to be an "empty" body.
+            data payload and are not considered to be an "empty" body.
           </p>
           <pre class="example" title="Event notification request">
             POST /listeners/bdd2aa13-387b-4c97-9725-52294a9fa5a9 HTTP/1.1

--- a/index.html
+++ b/index.html
@@ -1191,7 +1191,7 @@
               <li><code>Accept</code> header set to <code>application/json
               </code></li>
               <li><code>Content-Type</code> header set to <code>application/json
-              </code></li>
+              </code> (only if the action has an input)</li>
               <li>A body with an input to the action, if any, serialized in
                 JSON</li>
             </ul>
@@ -1206,6 +1206,16 @@
             "duration": 5
           }
           </pre>
+          <p>
+            <span class="rfc2119-assertion" id="http-basic-profile-protocol-binding-invokeaction-5">
+              If the action does not have an input then the <code>Content-type</code> header of 
+              the request SHOULD NOT be set, and the body should be empty.
+            </span>
+          </p>
+          <p class="note">
+            Valid JSON values such as <code>null</code>, <code>""</code> and <code>{}</code> could be a valid 
+            action input and are not be considered to be an "empty" body.
+          </p>
           <div class="rfc2119-assertion" id="http-basic-profile-protocol-binding-invokeaction-6">
             <p>
               If a Web Thing receives an HTTP request following the format
@@ -1389,17 +1399,25 @@
             <ul>
               <li>Status code set to <code>200</code></li>
               <li><code>Content-Type</code> header set to
-                <code>application/json</code>
+                <code>application/json</code> (only if the action has an output)
               </li>
               <li>A body containing the output of the action, if any, serialized
                 in JSON</li>
             </ul>
           </div>
+          <p>
+            <span class="rfc2119-assertion" id="http-basic-profile-protocol-binding-invokeaction-20a">
+              If the action does not have an output then the <code>Content-type</code> header of 
+              the request SHOULD NOT be set, and the body should be empty.
+            </span>
+          </p>
           <pre class="example">
             HTTP/1.1 200 OK
-            Content-Type: application/json
           </pre>
-
+          <p class="note">
+            Valid JSON values such as <code>null</code>, <code>""</code> and <code>{}</code> could be a valid 
+            action output and are not be considered to be an "empty" body.
+          </p>
           <h6 id="async-action-response">Asynchronous Action Response</h6>
           <div class="rfc2119-assertion" id="http-basic-profile-protocol-binding-invokeaction-21">
             <p>
@@ -3215,7 +3233,8 @@
             <ul>
               <li>Method set to <code>POST</code></li>
               <li>URL set to the callback URL provided by the <a>Consumer</a> when subscribing to the event</li>
-              <li><code>Content-Type</code> header set to <code>application/json</code></li>
+              <li><code>Content-Type</code> header set to <code>application/json</code> 
+                (only if the event has a data payload)</li>
               <li>A <code>Link</code> header with the URL set to the URL of the corresponding Event Affordance,
                 and <code>rel</code> set to <code>self</code></li>
               <li>A <code>Date</code> header automatically set to the time the event occurred by the 
@@ -3230,6 +3249,10 @@
             If the event does not include a data payload then the <code>Content-type</code> header of 
             the request SHOULD NOT be set, and the body should be empty.
           </span></p>
+          <p class="note">
+            Valid JSON values such as <code>null</code>, <code>""</code> and <code>{}</code> could be a valid 
+            data payload and are not be considered to be an "empty" body.
+          </p>
           <pre class="example" title="Event notification request">
             POST /listeners/e79dd0a5-4537-4ded-a10f-bb4eb2aca28d HTTP/1.1
             Host: myconsumer.com
@@ -3373,7 +3396,8 @@
             <ul>
               <li>Method set to <code>POST</code></li>
               <li>URL set to the callback URL provided by the <a>Consumer</a> when registering the subscription</li>
-              <li><code>Content-Type</code> header set to <code>application/json</code></li>
+              <li><code>Content-Type</code> header set to <code>application/json</code> 
+                (only if the event contains a data payload)</li>
               <li>A <code>Link</code> header with the URL set to the URL of the corresponding Event Affordance,
                 and <code>rel</code> set to <code>self</code></li>
               <li>A <code>Date</code> header automatically set to the time the event occurred by the 
@@ -3389,6 +3413,10 @@
             If the event does not include a data payload then the <code>Content-type</code> header of 
             the request SHOULD NOT be set, and the body should be empty.
           </span></p>
+          <p class="note">
+            Valid JSON values such as <code>null</code>, <code>""</code> and <code>{}</code> could be a valid 
+            data payload and are not be considered to be an "empty" body.
+          </p>
           <pre class="example" title="Event notification request">
             POST /listeners/bdd2aa13-387b-4c97-9725-52294a9fa5a9 HTTP/1.1
             Host: myconsumer.com

--- a/index.html
+++ b/index.html
@@ -1213,8 +1213,9 @@
             </span>
           </p>
           <p class="note">
-            Valid JSON values such as <code>null</code>, <code>""</code> and <code>{}</code> could be a valid 
-            action input and are not considered to be an "empty" body.
+            A valid JSON value &mdash; such as <code>null</code>, empty quotation marks 
+            (<code>""</code>), or empty braces (<code>{}</code>) &mdash; could be a valid 
+            action input and is not considered to be an "empty" body.
           </p>
           <div class="rfc2119-assertion" id="http-basic-profile-protocol-binding-invokeaction-6">
             <p>
@@ -1415,8 +1416,9 @@
             HTTP/1.1 200 OK
           </pre>
           <p class="note">
-            Valid JSON values such as <code>null</code>, <code>""</code> and <code>{}</code> could be a valid 
-            action output and are not considered to be an "empty" body.
+            A valid JSON value &mdash; such as <code>null</code>, empty quotation marks 
+            (<code>""</code>), or empty braces (<code>{}</code>) &mdash; could be a valid 
+            action output and is not considered to be an "empty" body.
           </p>
           <h6 id="async-action-response">Asynchronous Action Response</h6>
           <div class="rfc2119-assertion" id="http-basic-profile-protocol-binding-invokeaction-21">
@@ -3250,8 +3252,9 @@
             the request SHOULD NOT be set, and the body should be empty.
           </span></p>
           <p class="note">
-            Valid JSON values such as <code>null</code>, <code>""</code> and <code>{}</code> could be a valid 
-            data payload and are not considered to be an "empty" body.
+            A valid JSON value &mdash; such as <code>null</code>, empty quotation marks 
+            (<code>""</code>), or empty braces (<code>{}</code>) &mdash; could be a valid 
+            data payload and is not considered to be an "empty" body.
           </p>
           <pre class="example" title="Event notification request">
             POST /listeners/e79dd0a5-4537-4ded-a10f-bb4eb2aca28d HTTP/1.1
@@ -3414,8 +3417,9 @@
             the request SHOULD NOT be set, and the body should be empty.
           </span></p>
           <p class="note">
-            Valid JSON values such as <code>null</code>, <code>""</code> and <code>{}</code> could be a valid 
-            data payload and are not considered to be an "empty" body.
+            A valid JSON value &mdash; such as <code>null</code>, empty quotation marks 
+            (<code>""</code>), or empty braces (<code>{}</code>) &mdash; could be a valid 
+            data payload and is not considered to be an "empty" body.
           </p>
           <pre class="example" title="Event notification request">
             POST /listeners/bdd2aa13-387b-4c97-9725-52294a9fa5a9 HTTP/1.1

--- a/index.html
+++ b/index.html
@@ -1394,26 +1394,33 @@
           <h6 id="sync-action-response">Synchronous Action Response</h6>
           <div class="rfc2119-assertion" id="http-basic-profile-protocol-binding-invokeaction-20">
             <p>
-              If providing a Synchronous Action Response, a Web Thing MUST send
-              an HTTP response with:
+              If providing a Synchronous Action Response for an action with an output,
+              a Web Thing MUST send an HTTP response with:
             </p>
             <ul>
               <li>Status code set to <code>200</code></li>
-              <li><code>Content-Type</code> header set to
-                <code>application/json</code> (only if the action has an output)
-              </li>
-              <li>A body containing the output of the action, if any, serialized
-                in JSON</li>
+              <li><code>Content-Type</code> header set to <code>application/json</code></li>
+              <li>A body containing the output of the action, serialized in JSON</li>
             </ul>
           </div>
-          <p>
-            <span class="rfc2119-assertion" id="http-basic-profile-protocol-binding-invokeaction-20a">
-              If the action does not have an output then the <code>Content-type</code> header of 
-              the request SHOULD NOT be set, and the body should be empty.
-            </span>
-          </p>
-          <pre class="example">
+          <pre class="example" title="Synchronous action response with an output">
             HTTP/1.1 200 OK
+            Content-Type: application/json
+            20
+          </pre>
+          <div class="rfc2119-assertion" id="http-basic-profile-protocol-binding-invokeaction-20a">
+            <p>
+              If providing a Synchronous Action Response for an action with no output,
+              a Web Thing MUST send an HTTP response with:
+            </p>
+            <ul>
+              <li>Status code set to <code>204</code></li>
+              <li><code>Content-Type</code> header not set</li>
+              <li>An empty body</li>
+            </ul>
+          </div>
+          <pre class="example" title="Synchronous action response without an output"> 
+            HTTP/1.1 204 No Content
           </pre>
           <p class="note">
             A valid JSON value &mdash; such as <code>null</code>, empty quotation marks 


### PR DESCRIPTION
I had already added assertions to this effect to the events protocol binding in the HTTP Webhook Profile, but I've reviewed the rest of the text for all other uses of `Content-type` and made the following changes:
- Added an assertion not to include a `Content-type` header in an `invokeaction` request when there is no input
- Added an assertion not to include a `Content-type` header in an `invokeaction` response when there is no output
- Added notes to clarify what is meant by "empty body" for:
  - `invokeaction` request & response in the HTTP Basic Profile
  - `subscribeevent` in the HTTP Webhook Profile
  - `subscribeallevents` in the HTTP Webhook Profile

I don't think a clarification is needed for property related operations because when reading and writing properties there should *always* be a value, even if that value is `null`, so the `Content-type` header should always be set in a `writeproperty` request or a `readproperty` response (as is currently specified). Even for meta operations there would at least be an empty object or array.

I don't think clarification is needed for the HTTP SSE Profile because the `Content-type` is always `text/event-stream` regardless of whether an event has a data payload.

Let me know what you think.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/436.html" title="Last updated on Jul 29, 2025, 10:21 AM UTC (b90abc7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/436/b0a9374...benfrancis:b90abc7.html" title="Last updated on Jul 29, 2025, 10:21 AM UTC (b90abc7)">Diff</a>