### PR TITLE
Change document to Group Note and explain status of document - closes #432

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,21 +186,16 @@
       18 January 2023. The <a href="https://www.w3.org/WoT/wg/">WoT Working 
       Group</a> later decided not to continue to pursue the document to W3C
       Recommendation status and instead to publish it as a 
-      <a href="https://www.w3.org/standards/types/#x2-5-2-group-note">Group Note</a>.
-      This reflects the fact that whilst Web of Things (WoT) Profiles 1.0 is 
-      considered a useful and potentially implementable specification, it has
-      not undergone the level of rigorous testing that is required to reach W3C
-      Recommendation status.
+      <a href="https://www.w3.org/standards/types/#x2-5-2-group-note">Group Note</a>, 
+      as a useful point of reference for use with the WoT 1.x family of specifications.
+      A Group Note provides a stable reference for a document that is not intended 
+      to be a formal standard. Software MAY implement this specification at their own 
+      risk.
     </p>
     <p>
-      Due to publication timelines and difficulties integrating with the WoT
-      1.x family of specifications, the Working Group decided to publish WoT 
-      Profiles 1.0 as a Group Note to be a useful point of reference,
-      then switch their attention to a new recommendation track WoT Profiles 2.0
-      specification which better integrates with the WoT 2.x family of
-      specifications. Care should therefore be taken when implementing WoT
-      Profiles 1.0, since it is not considered a formal standard and may have
-      flaws which had not been identified at the time of publication.
+      Following the publication of this Note, the Working Group intends to switch
+      their attention to a new recommendation track WoT Profiles 2.0 specification 
+      for use with the WoT 2.x family of specifications.  
     </p>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
       lint: {
         "no-headingless-sections": false,
       },
-      specStatus: "ED",
+      specStatus: "NOTE",
       maxTocLevel: 6,
       processVersion: 2019,
       shortName: "wot-profile",
@@ -21,8 +21,8 @@
       edDraftURI: "https://w3c.github.io/wot-profile/",
       githubAPI: "https://api.github.com/repos/w3c/wot-profile",
       issueBase: "https://www.github.com/w3c/wot-profile/issues",
-      previousPublishDate: "2020-11-24",
-      previousMaturity: "FPWD",
+      previousPublishDate: "2023-01-18",
+      previousMaturity: "WD",
       editors: [{
         name: "Michael Lagally",
         w3cid: "47166",
@@ -176,7 +176,33 @@
     </p>
   </section>
 
-  <section id='sotd'></section>
+  <section id='sotd'>
+    <p>
+      This document was initially on the 
+      <a href="https://www.w3.org/policies/process/#rec-track">W3C 
+      Recommendation Track</a> and 
+      <a href="https://www.w3.org/TR/wot-profile/">published</a>
+      as a <a href="https://www.w3.org/standards/types/#WD">Working Draft</a> on
+      18 January 2023. The <a href="https://www.w3.org/WoT/wg/">WoT Working 
+      Group</a> later decided not to continue to pursue the document to W3C
+      Recommendation status and instead to publish it as a 
+      <a href="https://www.w3.org/standards/types/#x2-5-2-group-note">Group Note</a>.
+      This reflects the fact that whilst Web of Things (WoT) Profiles 1.0 is 
+      considered a useful and potentially implementable specification, it has
+      not undergone the level of rigorous testing that is required to reach W3C
+      Recommendation status.
+    </p>
+    <p>
+      Due to publication timelines and difficulties integrating with the WoT
+      1.x family of specifications, the Working Group decided to publish WoT 
+      Profiles 1.0 as a Group Note to be a useful point of reference,
+      then switch their attention to a new recommendation track WoT Profiles 2.0
+      specification which better integrates with the WoT 2.x family of
+      specifications. Care should therefore be taken when implementing WoT
+      Profiles 1.0, since it is not considered a formal standard and may have
+      flaws which had not been identified at the time of publication.
+    </p>
+  </section>
 
   <section id="introduction">
     <h1>Introduction</h1>


### PR DESCRIPTION
This PR changes the status of the document from ED (Editor's Draft) to NOTE (Group Note) and adds an explanation about the status of the document. Closes #432.

@ashimura I'm not sure whether the usual process is to land this change on the main branch first, or to do it when copying the specification to the publication folder, so I'm happy to change this PR to do the latter if necessary. In the meantime I would like to get a review of the proposed content itself.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/438.html" title="Last updated on Jul 30, 2025, 10:18 AM UTC (f655ac2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/438/b0a9374...benfrancis:f655ac2.html" title="Last updated on Jul 30, 2025, 10:18 AM UTC (f655ac2)">Diff</a>