### PR TITLE
Fix TD 1.1 reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -549,7 +549,7 @@
       </p>
       <p><span class="rfc2119-assertion" id="common-constraints-security-basic-in">
           For the <code>BasicSecurityScheme</code> the "in" field MUST be either omitted
-          or be given its default value of "header" as defined in [[wot-thing-description11].</span>
+          or be given its default value of "header" as defined in [[wot-thing-description11]].</span>
         <span class="rfc2119-assertion" id="common-constraints-security-basic-name">
           For the <code>BasicSecurityScheme</code> the "name" field MUST be provided using
           the value "Authorization" if a "proxy" endpoint is not given.</span>


### PR DESCRIPTION
fixes the syntax


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/pull/440.html" title="Last updated on Aug 4, 2025, 8:42 AM UTC (fe9afc7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/440/be817e1...fe9afc7.html" title="Last updated on Aug 4, 2025, 8:42 AM UTC (fe9afc7)">Diff</a>