### PR TITLE
Replace references to obsolete HTTP specification - closes #445

### DIFF
--- a/index.html
+++ b/index.html
@@ -582,7 +582,7 @@
         retrievable from a
         <a href="https://www.w3.org/TR/wot-architecture/#dfn-wot-thing-description-server">
           Thing Description Server</a> [[wot-architecture11]] using an HTTP
-        [[HTTP11]] URL provided by a
+          URL [[RFC9110]] provided by a
         <a href="https://www.w3.org/TR/wot-discovery/#introduction-direct">
           Direct Introduction Mechanism</a> [[wot-discovery]].
       </p>
@@ -788,7 +788,7 @@
         communicates with a
         <a>Web Thing</a>
         [[wot-architecture11]] using JSON [[JSON]] payloads over
-        the HTTP [[HTTP11]] protocol.
+        the HTTP protocol [[RFC9112]].
       </p>
       <p>
         <span class="rfc2119-assertion" id="profile-5-2-thing-protocol-binding-1">


### PR DESCRIPTION
Closes #445.

- First reference replaced with RFC9110 which defines the HTTP URI scheme
- Second reference replaced with RFC9112 which defines the HTTP message format


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/benfrancis/wot-profile/pull/446.html" title="Last updated on Sep 10, 2025, 9:01 AM UTC (b64ca7a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-profile/446/625a715...benfrancis:b64ca7a.html" title="Last updated on Sep 10, 2025, 9:01 AM UTC (b64ca7a)">Diff</a>