### PR TITLE
Move Michael McCool and Ryuichi Matsukura to former editors as requested

### DIFF
--- a/publication/3-wd/Overview.html
+++ b/publication/3-wd/Overview.html
@@ -180,18 +180,6 @@
       "company": "Invited Expert"
     },
     {
-      "name": "Michael McCool",
-      "w3cid": "93137",
-      "company": "Intel Corp.",
-      "companyURL": "https://www.intel.com/"
-    },
-    {
-      "name": "Ryuichi Matsukura",
-      "w3cid": "64284",
-      "company": "Fujitsu Ltd.",
-      "companyURL": "https://www.fujitsu.com/"
-    },
-    {
       "name": "Sebastian Kaebisch",
       "w3cid": "43064",
       "company": "Siemens AG",
@@ -202,6 +190,18 @@
       "w3cid": "98915",
       "company": "Internet Research Institute, Inc.",
       "companyURL": "https://www.iri.co.jp/"
+    }
+  ],
+  "formerEditors": [
+    {
+      "name": "Michael McCool",
+      "w3cid": "93137",
+      "company": "when at Intel Corp."
+    },
+    {
+      "name": "Ryuichi Matsukura",
+      "w3cid": "64284",
+      "company": "when at Fujitsu Ltd."
     }
   ],
   "otherLinks": [
@@ -244,8 +244,8 @@
       "id": "h2020-create-iot"
     }
   },
-  "publishISODate": "2025-09-17T00:00:00.000Z",
-  "generatedSubtitle": "W3C Working Draft 17 September 2025"
+  "publishISODate": "2025-09-30T00:00:00.000Z",
+  "generatedSubtitle": "W3C Working Draft 30 September 2025"
   }
   </script>
   <link rel="stylesheet" href=
@@ -260,7 +260,7 @@
     <h1 id="title" class="title">Web of Things (WoT) Profiles</h1>
     <p id="w3c-state"><a href=
     "https://www.w3.org/standards/types#WD">W3C Working Draft</a>
-    <time class="dt-published" datetime="2025-09-17">17 September
+    <time class="dt-published" datetime="2025-09-30">30 September
     2025</time></p>
     <details open="">
       <summary>
@@ -270,7 +270,7 @@
         <dt>This version:</dt>
         <dd>
           <a class="u-url" href=
-          "https://www.w3.org/TR/2025/WD-wot-profile-20250917/">https://www.w3.org/TR/2025/WD-wot-profile-20250917/</a>
+          "https://www.w3.org/TR/2025/WD-wot-profile-20250930/">https://www.w3.org/TR/2025/WD-wot-profile-20250930/</a>
         </dd>
         <dt>Latest published version:</dt>
         <dd>
@@ -303,18 +303,6 @@
         "51527"><span class="p-name fn">Ben Francis</span>
         (<span class="p-org org h-org">Invited Expert</span>)</dd>
         <dd class="editor p-author h-card vcard" data-editor-id=
-        "93137">
-          <span class="p-name fn">Michael McCool</span> (<a class=
-          "p-org org h-org" href="https://www.intel.com/">Intel
-          Corp.</a>)
-        </dd>
-        <dd class="editor p-author h-card vcard" data-editor-id=
-        "64284">
-          <span class="p-name fn">Ryuichi Matsukura</span>
-          (<a class="p-org org h-org" href=
-          "https://www.fujitsu.com/">Fujitsu Ltd.</a>)
-        </dd>
-        <dd class="editor p-author h-card vcard" data-editor-id=
         "43064">
           <span class="p-name fn">Sebastian Kaebisch</span>
           (<a class="p-org org h-org" href=
@@ -327,6 +315,15 @@
           "https://www.iri.co.jp/">Internet Research Institute,
           Inc.</a>)
         </dd>
+        <dt>Former editors:</dt>
+        <dd class="editor p-author h-card vcard" data-editor-id=
+        "93137"><span class="p-name fn">Michael McCool</span>
+        (<span class="p-org org h-org">when at Intel
+        Corp.</span>)</dd>
+        <dd class="editor p-author h-card vcard" data-editor-id=
+        "64284"><span class="p-name fn">Ryuichi Matsukura</span>
+        (<span class="p-org org h-org">when at Fujitsu
+        Ltd.</span>)</dd>
         <dt>Feedback:</dt>
         <dd>
           <a href="https://github.com/w3c/wot-profile/">GitHub

--- a/publication/3-wd/index.html
+++ b/publication/3-wd/index.html
@@ -34,18 +34,6 @@
       },
 
       {
-        name: "Michael McCool",
-        w3cid: "93137",
-        company: "Intel Corp.",
-        companyURL: "https://www.intel.com/"
-      },
-      {
-        name: "Ryuichi Matsukura",
-        w3cid: "64284",
-        company: "Fujitsu Ltd.",
-        companyURL: "https://www.fujitsu.com/"
-      },
-      {
         name: "Sebastian Kaebisch",
         w3cid: "43064",
         company: "Siemens AG",
@@ -57,7 +45,16 @@
         company: "Internet Research Institute, Inc.",
         companyURL: "https://www.iri.co.jp/"
       }],
-
+      formerEditors: [{
+        name: "Michael McCool",
+        w3cid: "93137",
+        company: "when at Intel Corp.",
+      },
+      {
+        name: "Ryuichi Matsukura",
+        w3cid: "64284",
+        company: "when at Fujitsu Ltd.",
+      }],
       otherLinks: [
         {
           key: "Contributors",

--- a/publication/3-wd/static.html
+++ b/publication/3-wd/static.html
@@ -187,18 +187,6 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "company": "Invited Expert"
     },
     {
-      "name": "Michael McCool",
-      "w3cid": "93137",
-      "company": "Intel Corp.",
-      "companyURL": "https://www.intel.com/"
-    },
-    {
-      "name": "Ryuichi Matsukura",
-      "w3cid": "64284",
-      "company": "Fujitsu Ltd.",
-      "companyURL": "https://www.fujitsu.com/"
-    },
-    {
       "name": "Sebastian Kaebisch",
       "w3cid": "43064",
       "company": "Siemens AG",
@@ -209,6 +197,18 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "w3cid": "98915",
       "company": "Internet Research Institute, Inc.",
       "companyURL": "https://www.iri.co.jp/"
+    }
+  ],
+  "formerEditors": [
+    {
+      "name": "Michael McCool",
+      "w3cid": "93137",
+      "company": "when at Intel Corp."
+    },
+    {
+      "name": "Ryuichi Matsukura",
+      "w3cid": "64284",
+      "company": "when at Fujitsu Ltd."
     }
   ],
   "otherLinks": [
@@ -251,8 +251,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "id": "h2020-create-iot"
     }
   },
-  "publishISODate": "2025-09-17T00:00:00.000Z",
-  "generatedSubtitle": "W3C Working Draft 17 September 2025"
+  "publishISODate": "2025-09-30T00:00:00.000Z",
+  "generatedSubtitle": "W3C Working Draft 30 September 2025"
 }</script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-WD"></head>
 
@@ -260,12 +260,12 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     <p class="logos"><a class="logo" href="https://www.w3.org/"><img crossorigin="" alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
   </a></p>
     <h1 id="title" class="title">Web of Things (WoT) Profiles</h1> 
-    <p id="w3c-state"><a href="https://www.w3.org/standards/types#WD">W3C Working Draft</a> <time class="dt-published" datetime="2025-09-17">17 September 2025</time></p>
+    <p id="w3c-state"><a href="https://www.w3.org/standards/types#WD">W3C Working Draft</a> <time class="dt-published" datetime="2025-09-30">30 September 2025</time></p>
     <details open="">
       <summary>More details about this document</summary>
       <dl>
         <dt>This version:</dt><dd>
-                <a class="u-url" href="https://www.w3.org/TR/2025/WD-wot-profile-20250917/">https://www.w3.org/TR/2025/WD-wot-profile-20250917/</a>
+                <a class="u-url" href="https://www.w3.org/TR/2025/WD-wot-profile-20250930/">https://www.w3.org/TR/2025/WD-wot-profile-20250930/</a>
               </dd>
         <dt>Latest published version:</dt><dd>
                 <a href="https://www.w3.org/TR/wot-profile/">https://www.w3.org/TR/wot-profile/</a>
@@ -285,16 +285,18 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     <span class="p-name fn">Michael Lagally</span> (<a class="p-org org h-org" href="https://www.oracle.com/">Oracle Corp.</a>)
   </dd><dd class="editor p-author h-card vcard" data-editor-id="51527">
     <span class="p-name fn">Ben Francis</span> (<span class="p-org org h-org">Invited Expert</span>)
-  </dd><dd class="editor p-author h-card vcard" data-editor-id="93137">
-    <span class="p-name fn">Michael McCool</span> (<a class="p-org org h-org" href="https://www.intel.com/">Intel Corp.</a>)
-  </dd><dd class="editor p-author h-card vcard" data-editor-id="64284">
-    <span class="p-name fn">Ryuichi Matsukura</span> (<a class="p-org org h-org" href="https://www.fujitsu.com/">Fujitsu Ltd.</a>)
   </dd><dd class="editor p-author h-card vcard" data-editor-id="43064">
     <span class="p-name fn">Sebastian Kaebisch</span> (<a class="p-org org h-org" href="https://www.siemens.com/">Siemens AG</a>)
   </dd><dd class="editor p-author h-card vcard" data-editor-id="98915">
     <span class="p-name fn">Tomoaki Mizushima</span> (<a class="p-org org h-org" href="https://www.iri.co.jp/">Internet Research Institute, Inc.</a>)
   </dd>
-        
+        <dt>
+                Former editors:
+              </dt><dd class="editor p-author h-card vcard" data-editor-id="93137">
+    <span class="p-name fn">Michael McCool</span> (<span class="p-org org h-org">when at Intel Corp.</span>)
+  </dd><dd class="editor p-author h-card vcard" data-editor-id="64284">
+    <span class="p-name fn">Ryuichi Matsukura</span> (<span class="p-org org h-org">when at Fujitsu Ltd.</span>)
+  </dd>
         
         <dt>Feedback:</dt><dd>
         <a href="https://github.com/w3c/wot-profile/">GitHub w3c/wot-profile</a>


### PR DESCRIPTION
Move Michael McCool and Ryuichi Matsukura to former editors in the latest Working Draft,  as requested in https://www.w3.org/2025/09/24-wot-minutes.html, in order to pass Pubrules checks.