### PR TITLE
Remove link to missing atrisk CSS file

### DIFF
--- a/publication/3-wd/Overview.html
+++ b/publication/3-wd/Overview.html
@@ -4,7 +4,7 @@
   <meta name="generator" content=
   "HTML Tidy for HTML5 for Linux version 5.6.0">
   <meta charset="utf-8">
-  <meta name="generator" content="ReSpec 35.5.1">
+  <meta name="generator" content="ReSpec 35.6.0">
   <meta name="viewport" content=
   "width=device-width, initial-scale=1, shrink-to-fit=no">
   <style>
@@ -47,7 +47,6 @@
   .dfn-panel li{margin-left:1em}
   .dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
   </style>
-  <link rel="stylesheet" href="testing/atrisk.css">
   <title>Web of Things (WoT) Profiles</title>
   <style id="respec-mainstyle">
   @keyframes pop{
@@ -244,8 +243,8 @@
       "id": "h2020-create-iot"
     }
   },
-  "publishISODate": "2025-09-30T00:00:00.000Z",
-  "generatedSubtitle": "W3C Working Draft 30 September 2025"
+  "publishISODate": "2025-10-28T00:00:00.000Z",
+  "generatedSubtitle": "W3C Working Draft 28 October 2025"
   }
   </script>
   <link rel="stylesheet" href=
@@ -260,7 +259,7 @@
     <h1 id="title" class="title">Web of Things (WoT) Profiles</h1>
     <p id="w3c-state"><a href=
     "https://www.w3.org/standards/types#WD">W3C Working Draft</a>
-    <time class="dt-published" datetime="2025-09-30">30 September
+    <time class="dt-published" datetime="2025-10-28">28 October
     2025</time></p>
     <details open="">
       <summary>
@@ -270,7 +269,7 @@
         <dt>This version:</dt>
         <dd>
           <a class="u-url" href=
-          "https://www.w3.org/TR/2025/WD-wot-profile-20250930/">https://www.w3.org/TR/2025/WD-wot-profile-20250930/</a>
+          "https://www.w3.org/TR/2025/WD-wot-profile-20251028/">https://www.w3.org/TR/2025/WD-wot-profile-20251028/</a>
         </dd>
         <dt>Latest published version:</dt>
         <dd>

--- a/publication/3-wd/index.html
+++ b/publication/3-wd/index.html
@@ -2,7 +2,6 @@
 <html lang="en-US">
 
 <head>
-  <link rel="stylesheet" href="testing/atrisk.css">
   <meta charset="utf-8" />
   <title>Web of Things (WoT) Profiles</title>
   <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>

--- a/publication/3-wd/static.html
+++ b/publication/3-wd/static.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en-US"><head>
 <meta charset="utf-8">
-<meta name="generator" content="ReSpec 35.5.1">
+<meta name="generator" content="ReSpec 35.6.0">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <style>
 span.example-title{text-transform:none}
@@ -42,8 +42,6 @@ dfn{cursor:pointer}
 .dfn-panel li{margin-left:1em}
 .dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
 </style>
-  
-<link rel="stylesheet" href="testing/atrisk.css">
   
   
 <title>Web of Things (WoT) Profiles</title>
@@ -251,8 +249,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "id": "h2020-create-iot"
     }
   },
-  "publishISODate": "2025-09-30T00:00:00.000Z",
-  "generatedSubtitle": "W3C Working Draft 30 September 2025"
+  "publishISODate": "2025-10-28T00:00:00.000Z",
+  "generatedSubtitle": "W3C Working Draft 28 October 2025"
 }</script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-WD"></head>
 
@@ -260,12 +258,12 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     <p class="logos"><a class="logo" href="https://www.w3.org/"><img crossorigin="" alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
   </a></p>
     <h1 id="title" class="title">Web of Things (WoT) Profiles</h1> 
-    <p id="w3c-state"><a href="https://www.w3.org/standards/types#WD">W3C Working Draft</a> <time class="dt-published" datetime="2025-09-30">30 September 2025</time></p>
+    <p id="w3c-state"><a href="https://www.w3.org/standards/types#WD">W3C Working Draft</a> <time class="dt-published" datetime="2025-10-28">28 October 2025</time></p>
     <details open="">
       <summary>More details about this document</summary>
       <dl>
         <dt>This version:</dt><dd>
-                <a class="u-url" href="https://www.w3.org/TR/2025/WD-wot-profile-20250930/">https://www.w3.org/TR/2025/WD-wot-profile-20250930/</a>
+                <a class="u-url" href="https://www.w3.org/TR/2025/WD-wot-profile-20251028/">https://www.w3.org/TR/2025/WD-wot-profile-20251028/</a>
               </dd>
         <dt>Latest published version:</dt><dd>
                 <a href="https://www.w3.org/TR/wot-profile/">https://www.w3.org/TR/wot-profile/</a>


### PR DESCRIPTION
There is a link to atrisk.css which is not included in the publication folder, so results in a 404 error, which is apparently blocking publication.

I've removed the link to [atrisk.css](https://github.com/w3c/wot-profile/blob/main/testing/atrisk.css) since all of the lines of that file are commented out anyway because the assertion numbers are obsolete since we re-worked the specification.

This is a one line change in index.html to remove a broken link that is not currently needed. The rest of the diff is auto-generated by Respec and tidy.