### PR TITLE
Add Editor's Notes about open discussion around use cases & requirements

### DIFF
--- a/requirements/index.html
+++ b/requirements/index.html
@@ -100,10 +100,10 @@
       The final version of this document should include or reference a broader set of use cases from different
       application domains, and we welcome further submissions. Please see <a
         href="https://github.com/w3c/wot-profile/issues?q=is%3Aissue%20state%3Aopen%20label%3AProfile-2.0%20label%3A%22use%20case%22">
-        issues</a> on GitHub. It should also be clarified how the use cases in this document relate to the high level
+        issues</a> on GitHub. This document should also clarify how the use cases it contains relate to the high level
       use cases defined in the <a href="https://www.w3.org/TR/wot-usecases/">Web of Things (WoT): Use Cases &
-        Requirements</a> [[wot-usecases]] document, e.g. 
-        <a href="https://www.w3.org/TR/wot-usecases/#multi-vendor">"Multi-Vendor System Integration - Out of the box
+        Requirements</a> [[wot-usecases]] document, e.g., 
+        <a href="https://www.w3.org/TR/wot-usecases/#multi-vendor">"Multi-Vendor System Integration — Out of the box
       interoperability"</a>.
     </p>
   </section>
@@ -185,10 +185,11 @@
     </section>
     <p class="ednote" title="Open topics of discussion">
       There are still open topics of discussion around the precise requirements for the Profile Registry and Profile 
-      Registry Entries, e.g. whether application domain specific Profiles will be permitted and whether Profiles should
+      Registry Entries, e.g., whether application-domain-specific Profiles will be permitted, and whether Profiles should
       constrain which interaction affordances and data schemas a Thing can use. Please see the
       <a
-        href="https://github.com/w3c/wot-profile/issues?q=is%3Aissue%20state%3Aopen%20label%3AProfile-2.0%20label%3Arequirement">issues</a>
+        href="https://github.com/w3c/wot-profile/issues?q=is%3Aissue%20state%3Aopen%20label%3AProfile-2.0%20label%3Arequirement"
+        >issues</a>
       on GitHub for open topics of discussion.
     </p>
   </section>

--- a/requirements/index.html
+++ b/requirements/index.html
@@ -95,6 +95,17 @@
         having to implement multiple vendor-specific APIs.
       </p>
     </section>
+
+    <p class="ednote" title="Additional use cases">
+      The final version of this document should include or reference a broader set of use cases from different
+      application domains, and we welcome further submissions. Please see <a
+        href="https://github.com/w3c/wot-profile/issues?q=is%3Aissue%20state%3Aopen%20label%3AProfile-2.0%20label%3A%22use%20case%22">
+        issues</a> on GitHub. It should also be clarified how the use cases in this document relate to the high level
+      use cases defined in the <a href="https://www.w3.org/TR/wot-usecases/">Web of Things (WoT): Use Cases &
+        Requirements</a> [[wot-usecases]] document, e.g. 
+        <a href="https://www.w3.org/TR/wot-usecases/#multi-vendor">"Multi-Vendor System Integration - Out of the box
+      interoperability"</a>.
+    </p>
   </section>
 
   <section id="requirements">
@@ -171,15 +182,15 @@
           domain.</li>
         <li>Profiles shall not be used to describe an existing single-vendor IoT platform.</li>
       </ol>
-      <p class="ednote" title="Open topics of discussion">
-        There are still open topics of discussion around the precise requirements for Profile Registry Entries, e.g.
-        whether application domain specific Profiles will be permitted and whether Profiles should constrain which
-        interaction affordances and data schemas a Thing can use. Please see the
-        <a
-          href="https://github.com/w3c/wot-profile/issues?q=is%3Aissue%20state%3Aopen%20label%3AProfile-2.0%20label%3Arequirement">issues</a>
-        on GitHub for open topics of discussion.
-      </p>
     </section>
+    <p class="ednote" title="Open topics of discussion">
+      There are still open topics of discussion around the precise requirements for the Profile Registry and Profile 
+      Registry Entries, e.g. whether application domain specific Profiles will be permitted and whether Profiles should
+      constrain which interaction affordances and data schemas a Thing can use. Please see the
+      <a
+        href="https://github.com/w3c/wot-profile/issues?q=is%3Aissue%20state%3Aopen%20label%3AProfile-2.0%20label%3Arequirement">issues</a>
+      on GitHub for open topics of discussion.
+    </p>
   </section>
 
 </body>

--- a/requirements/index.html
+++ b/requirements/index.html
@@ -165,12 +165,20 @@
           document.</li>
         <li>Profiles shall not include any assertions which would cause a Thing Description of a conformant Web Thing
           to be non-conformant with the Thing Description 2.0 specification.</li>
-        <li>Profiles registered in the Profile Registry should avoid including assertions which conflict with 
+        <li>Profiles registered in the Profile Registry should avoid including assertions which conflict with
           assertions in other Profiles in the Profile Registry, so that Things may conform to multiple Profiles.</li>
         <li>In order to maximize cross-domain interoperability, Profiles shall not be specific to a single application
           domain.</li>
         <li>Profiles shall not be used to describe an existing single-vendor IoT platform.</li>
       </ol>
+      <p class="ednote" title="Open topics of discussion">
+        There are still open topics of discussion around the precise requirements for Profile Registry Entries, e.g.
+        whether application domain specific Profiles will be permitted and whether Profiles should constrain which
+        interaction affordances and data schemas a Thing can use. Please see the
+        <a
+          href="https://github.com/w3c/wot-profile/issues?q=is%3Aissue%20state%3Aopen%20label%3AProfile-2.0%20label%3Arequirement">issues</a>
+        on GitHub for open topics of discussion.
+      </p>
     </section>
   </section>
 


### PR DESCRIPTION
This PR proposes adding two Editor's Notes to the Use Cases & requirements document to address topics raised in the WoT Main call today:
1. To highlight that the final document should contain or reference a broader set of use cases and the relationship with the high level Use Cases & Requirements document should be clarified
2. To highlight open topics of discussion around the requirements